### PR TITLE
Support to ensure schemas

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,6 +12,7 @@ repos:
       - id: check-yaml
       - id: pretty-format-json
         args:
+          - --indent 4
           - --autofix
           - --no-ensure-ascii
           - --no-sort-keys

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,7 +45,7 @@ repos:
           - pep8-naming==0.13.1
 
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.37.3
+    rev: v2.38.2
     hooks:
       - id: pyupgrade
         args:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,6 @@ repos:
       - id: check-yaml
       - id: pretty-format-json
         args:
-          - --indent 4
           - --autofix
           - --no-ensure-ascii
           - --no-sort-keys

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,8 +4,10 @@
   "python.linting.flake8CategorySeverity.E": "Information",
   "python.linting.flake8CategorySeverity.W": "Information",
   "python.formatting.provider": "black",
-  "editor.formatOnPaste": false,
-  "editor.formatOnSave": true,
+  "[python]": {
+    "editor.formatOnPaste": false,
+    "editor.formatOnSave": true
+  },
   "python.linting.mypyEnabled": true,
   "python.linting.mypyCategorySeverity.error": "Information",
   "python.testing.pytestArgs": [

--- a/src/etl/common/ETLSession.py
+++ b/src/etl/common/ETLSession.py
@@ -1,13 +1,18 @@
 from __future__ import annotations
 
+import json
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from pyspark.sql import SparkSession
+from pyspark.sql.types import StructType
 
 from etl.common import Log4j
+from etl.json import SCHEMA_DIR
 
 if TYPE_CHECKING:
     from omegaconf import DictConfig
+    from pyspark.sql import DataFrame
 
 
 class ETLSession:
@@ -20,3 +25,12 @@ class ETLSession:
         )
 
         self.logger = Log4j.Log4j(self.spark)
+
+    def read_parquet(self: ETLSession, path: str, schema_json: str) -> DataFrame:
+        core_schema = json.loads(
+            Path(SCHEMA_DIR, schema_json).read_text(encoding="utf-8")
+        )
+        schema = StructType.fromJson(core_schema)
+        df = self.spark.read.schema(schema).format("parquet").load(path)
+
+        return df

--- a/src/etl/json/__init__.py
+++ b/src/etl/json/__init__.py
@@ -1,5 +1,27 @@
 from __future__ import annotations
 
+import json
 import os
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from pyspark.sql.types import StructType
+
+if TYPE_CHECKING:
+    from pyspark.sql import DataFrame
 
 SCHEMA_DIR = os.path.join(os.path.dirname(__file__), "schemas")
+
+
+def validate_df_schema(df: DataFrame, schema_json: str):
+    core_schema = json.loads(Path(SCHEMA_DIR, schema_json).read_text(encoding="utf-8"))
+    expected_schema = StructType.fromJson(core_schema)
+    observed_schema = df.schema
+    missing_struct_fields = [x for x in observed_schema if x not in expected_schema]
+    error_message = "The {missing_struct_fields} StructFields are not included in the {schema_json} DataFrame schema: {all_struct_fields}".format(
+        missing_struct_fields=missing_struct_fields,
+        schema_json=schema_json,
+        all_struct_fields=expected_schema,
+    )
+    if missing_struct_fields:
+        raise Exception(error_message)

--- a/src/etl/json/__init__.py
+++ b/src/etl/json/__init__.py
@@ -13,15 +13,11 @@ if TYPE_CHECKING:
 SCHEMA_DIR = os.path.join(os.path.dirname(__file__), "schemas")
 
 
-def validate_df_schema(df: DataFrame, schema_json: str):
+def validate_df_schema(df: DataFrame, schema_json: str) -> None:
     core_schema = json.loads(Path(SCHEMA_DIR, schema_json).read_text(encoding="utf-8"))
     expected_schema = StructType.fromJson(core_schema)
     observed_schema = df.schema
     missing_struct_fields = [x for x in observed_schema if x not in expected_schema]
-    error_message = "The {missing_struct_fields} StructFields are not included in the {schema_json} DataFrame schema: {all_struct_fields}".format(
-        missing_struct_fields=missing_struct_fields,
-        schema_json=schema_json,
-        all_struct_fields=expected_schema,
-    )
+    error_message = f"The {missing_struct_fields} StructFields are not included in the {schema_json} DataFrame schema: {expected_schema}"
     if missing_struct_fields:
         raise Exception(error_message)

--- a/src/etl/json/__init__.py
+++ b/src/etl/json/__init__.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+import os
+
+SCHEMA_DIR = os.path.join(os.path.dirname(__file__), "schemas")

--- a/src/etl/json/schemas/intervals.json
+++ b/src/etl/json/schemas/intervals.json
@@ -1,0 +1,83 @@
+{
+  "fields": [
+    {
+      "metadata": {},
+      "name": "chromosome",
+      "nullable": true,
+      "type": "string"
+    },
+    {
+      "metadata": {},
+      "name": "start",
+      "nullable": true,
+      "type": "string"
+    },
+    {
+      "metadata": {},
+      "name": "end",
+      "nullable": true,
+      "type": "string"
+    },
+    {
+      "metadata": {},
+      "name": "geneId",
+      "nullable": true,
+      "type": "string"
+    },
+    {
+      "metadata": {},
+      "name": "score",
+      "nullable": true,
+      "type": "double"
+    },
+    {
+      "metadata": {},
+      "name": "datasetName",
+      "nullable": true,
+      "type": "string"
+    },
+    {
+      "metadata": {},
+      "name": "dataType",
+      "nullable": true,
+      "type": "string"
+    },
+    {
+      "metadata": {},
+      "name": "experimentType",
+      "nullable": true,
+      "type": "string"
+    },
+    {
+      "metadata": {},
+      "name": "pmid",
+      "nullable": true,
+      "type": "string"
+    },
+    {
+      "metadata": {},
+      "name": "bioFeature",
+      "nullable": true,
+      "type": "string"
+    },
+    {
+      "metadata": {},
+      "name": "dataset_name",
+      "nullable": true,
+      "type": "string"
+    },
+    {
+      "metadata": {},
+      "name": "data_type",
+      "nullable": true,
+      "type": "string"
+    },
+    {
+      "metadata": {},
+      "name": "experiment_type",
+      "nullable": true,
+      "type": "string"
+    }
+  ],
+  "type": "struct"
+}

--- a/src/etl/json/schemas/targets.json
+++ b/src/etl/json/schemas/targets.json
@@ -1,0 +1,1025 @@
+{
+    "fields": [
+        {
+            "metadata": {},
+            "name": "id",
+            "nullable": true,
+            "type": "string"
+        },
+        {
+            "metadata": {},
+            "name": "approvedSymbol",
+            "nullable": true,
+            "type": "string"
+        },
+        {
+            "metadata": {},
+            "name": "biotype",
+            "nullable": true,
+            "type": "string"
+        },
+        {
+            "metadata": {},
+            "name": "transcriptIds",
+            "nullable": true,
+            "type": {
+                "containsNull": true,
+                "elementType": "string",
+                "type": "array"
+            }
+        },
+        {
+            "metadata": {},
+            "name": "canonicalTranscript",
+            "nullable": true,
+            "type": {
+                "fields": [
+                    {
+                        "metadata": {},
+                        "name": "id",
+                        "nullable": true,
+                        "type": "string"
+                    },
+                    {
+                        "metadata": {},
+                        "name": "chromosome",
+                        "nullable": true,
+                        "type": "string"
+                    },
+                    {
+                        "metadata": {},
+                        "name": "start",
+                        "nullable": true,
+                        "type": "long"
+                    },
+                    {
+                        "metadata": {},
+                        "name": "end",
+                        "nullable": true,
+                        "type": "long"
+                    },
+                    {
+                        "metadata": {},
+                        "name": "strand",
+                        "nullable": true,
+                        "type": "string"
+                    }
+                ],
+                "type": "struct"
+            }
+        },
+        {
+            "metadata": {},
+            "name": "canonicalExons",
+            "nullable": true,
+            "type": {
+                "containsNull": true,
+                "elementType": "string",
+                "type": "array"
+            }
+        },
+        {
+            "metadata": {},
+            "name": "genomicLocation",
+            "nullable": true,
+            "type": {
+                "fields": [
+                    {
+                        "metadata": {},
+                        "name": "chromosome",
+                        "nullable": true,
+                        "type": "string"
+                    },
+                    {
+                        "metadata": {},
+                        "name": "start",
+                        "nullable": true,
+                        "type": "long"
+                    },
+                    {
+                        "metadata": {},
+                        "name": "end",
+                        "nullable": true,
+                        "type": "long"
+                    },
+                    {
+                        "metadata": {},
+                        "name": "strand",
+                        "nullable": true,
+                        "type": "integer"
+                    }
+                ],
+                "type": "struct"
+            }
+        },
+        {
+            "metadata": {},
+            "name": "alternativeGenes",
+            "nullable": true,
+            "type": {
+                "containsNull": true,
+                "elementType": "string",
+                "type": "array"
+            }
+        },
+        {
+            "metadata": {},
+            "name": "approvedName",
+            "nullable": true,
+            "type": "string"
+        },
+        {
+            "metadata": {},
+            "name": "go",
+            "nullable": true,
+            "type": {
+                "containsNull": true,
+                "elementType": {
+                    "fields": [
+                        {
+                            "metadata": {},
+                            "name": "id",
+                            "nullable": true,
+                            "type": "string"
+                        },
+                        {
+                            "metadata": {},
+                            "name": "source",
+                            "nullable": true,
+                            "type": "string"
+                        },
+                        {
+                            "metadata": {},
+                            "name": "evidence",
+                            "nullable": true,
+                            "type": "string"
+                        },
+                        {
+                            "metadata": {},
+                            "name": "aspect",
+                            "nullable": true,
+                            "type": "string"
+                        },
+                        {
+                            "metadata": {},
+                            "name": "geneProduct",
+                            "nullable": true,
+                            "type": "string"
+                        },
+                        {
+                            "metadata": {},
+                            "name": "ecoId",
+                            "nullable": true,
+                            "type": "string"
+                        }
+                    ],
+                    "type": "struct"
+                },
+                "type": "array"
+            }
+        },
+        {
+            "metadata": {},
+            "name": "hallmarks",
+            "nullable": true,
+            "type": {
+                "fields": [
+                    {
+                        "metadata": {},
+                        "name": "attributes",
+                        "nullable": true,
+                        "type": {
+                            "containsNull": true,
+                            "elementType": {
+                                "fields": [
+                                    {
+                                        "metadata": {},
+                                        "name": "pmid",
+                                        "nullable": true,
+                                        "type": "long"
+                                    },
+                                    {
+                                        "metadata": {},
+                                        "name": "description",
+                                        "nullable": true,
+                                        "type": "string"
+                                    },
+                                    {
+                                        "metadata": {},
+                                        "name": "attribute_name",
+                                        "nullable": true,
+                                        "type": "string"
+                                    }
+                                ],
+                                "type": "struct"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    {
+                        "metadata": {},
+                        "name": "cancerHallmarks",
+                        "nullable": true,
+                        "type": {
+                            "containsNull": true,
+                            "elementType": {
+                                "fields": [
+                                    {
+                                        "metadata": {},
+                                        "name": "pmid",
+                                        "nullable": true,
+                                        "type": "long"
+                                    },
+                                    {
+                                        "metadata": {},
+                                        "name": "description",
+                                        "nullable": true,
+                                        "type": "string"
+                                    },
+                                    {
+                                        "metadata": {},
+                                        "name": "impact",
+                                        "nullable": true,
+                                        "type": "string"
+                                    },
+                                    {
+                                        "metadata": {},
+                                        "name": "label",
+                                        "nullable": true,
+                                        "type": "string"
+                                    }
+                                ],
+                                "type": "struct"
+                            },
+                            "type": "array"
+                        }
+                    }
+                ],
+                "type": "struct"
+            }
+        },
+        {
+            "metadata": {},
+            "name": "synonyms",
+            "nullable": true,
+            "type": {
+                "containsNull": true,
+                "elementType": {
+                    "fields": [
+                        {
+                            "metadata": {},
+                            "name": "label",
+                            "nullable": true,
+                            "type": "string"
+                        },
+                        {
+                            "metadata": {},
+                            "name": "source",
+                            "nullable": true,
+                            "type": "string"
+                        }
+                    ],
+                    "type": "struct"
+                },
+                "type": "array"
+            }
+        },
+        {
+            "metadata": {},
+            "name": "symbolSynonyms",
+            "nullable": true,
+            "type": {
+                "containsNull": true,
+                "elementType": {
+                    "fields": [
+                        {
+                            "metadata": {},
+                            "name": "label",
+                            "nullable": true,
+                            "type": "string"
+                        },
+                        {
+                            "metadata": {},
+                            "name": "source",
+                            "nullable": true,
+                            "type": "string"
+                        }
+                    ],
+                    "type": "struct"
+                },
+                "type": "array"
+            }
+        },
+        {
+            "metadata": {},
+            "name": "nameSynonyms",
+            "nullable": true,
+            "type": {
+                "containsNull": true,
+                "elementType": {
+                    "fields": [
+                        {
+                            "metadata": {},
+                            "name": "label",
+                            "nullable": true,
+                            "type": "string"
+                        },
+                        {
+                            "metadata": {},
+                            "name": "source",
+                            "nullable": true,
+                            "type": "string"
+                        }
+                    ],
+                    "type": "struct"
+                },
+                "type": "array"
+            }
+        },
+        {
+            "metadata": {},
+            "name": "functionDescriptions",
+            "nullable": true,
+            "type": {
+                "containsNull": true,
+                "elementType": "string",
+                "type": "array"
+            }
+        },
+        {
+            "metadata": {},
+            "name": "subcellularLocations",
+            "nullable": true,
+            "type": {
+                "containsNull": true,
+                "elementType": {
+                    "fields": [
+                        {
+                            "metadata": {},
+                            "name": "location",
+                            "nullable": true,
+                            "type": "string"
+                        },
+                        {
+                            "metadata": {},
+                            "name": "source",
+                            "nullable": true,
+                            "type": "string"
+                        },
+                        {
+                            "metadata": {},
+                            "name": "termSL",
+                            "nullable": true,
+                            "type": "string"
+                        },
+                        {
+                            "metadata": {},
+                            "name": "labelSL",
+                            "nullable": true,
+                            "type": "string"
+                        }
+                    ],
+                    "type": "struct"
+                },
+                "type": "array"
+            }
+        },
+        {
+            "metadata": {},
+            "name": "targetClass",
+            "nullable": true,
+            "type": {
+                "containsNull": true,
+                "elementType": {
+                    "fields": [
+                        {
+                            "metadata": {},
+                            "name": "id",
+                            "nullable": true,
+                            "type": "long"
+                        },
+                        {
+                            "metadata": {},
+                            "name": "label",
+                            "nullable": true,
+                            "type": "string"
+                        },
+                        {
+                            "metadata": {},
+                            "name": "level",
+                            "nullable": true,
+                            "type": "string"
+                        }
+                    ],
+                    "type": "struct"
+                },
+                "type": "array"
+            }
+        },
+        {
+            "metadata": {},
+            "name": "obsoleteSymbols",
+            "nullable": true,
+            "type": {
+                "containsNull": true,
+                "elementType": {
+                    "fields": [
+                        {
+                            "metadata": {},
+                            "name": "label",
+                            "nullable": true,
+                            "type": "string"
+                        },
+                        {
+                            "metadata": {},
+                            "name": "source",
+                            "nullable": true,
+                            "type": "string"
+                        }
+                    ],
+                    "type": "struct"
+                },
+                "type": "array"
+            }
+        },
+        {
+            "metadata": {},
+            "name": "obsoleteNames",
+            "nullable": true,
+            "type": {
+                "containsNull": true,
+                "elementType": {
+                    "fields": [
+                        {
+                            "metadata": {},
+                            "name": "label",
+                            "nullable": true,
+                            "type": "string"
+                        },
+                        {
+                            "metadata": {},
+                            "name": "source",
+                            "nullable": true,
+                            "type": "string"
+                        }
+                    ],
+                    "type": "struct"
+                },
+                "type": "array"
+            }
+        },
+        {
+            "metadata": {},
+            "name": "constraint",
+            "nullable": true,
+            "type": {
+                "containsNull": true,
+                "elementType": {
+                    "fields": [
+                        {
+                            "metadata": {},
+                            "name": "constraintType",
+                            "nullable": true,
+                            "type": "string"
+                        },
+                        {
+                            "metadata": {},
+                            "name": "score",
+                            "nullable": true,
+                            "type": "float"
+                        },
+                        {
+                            "metadata": {},
+                            "name": "exp",
+                            "nullable": true,
+                            "type": "float"
+                        },
+                        {
+                            "metadata": {},
+                            "name": "obs",
+                            "nullable": true,
+                            "type": "integer"
+                        },
+                        {
+                            "metadata": {},
+                            "name": "oe",
+                            "nullable": true,
+                            "type": "float"
+                        },
+                        {
+                            "metadata": {},
+                            "name": "oeLower",
+                            "nullable": true,
+                            "type": "float"
+                        },
+                        {
+                            "metadata": {},
+                            "name": "oeUpper",
+                            "nullable": true,
+                            "type": "float"
+                        },
+                        {
+                            "metadata": {},
+                            "name": "upperRank",
+                            "nullable": true,
+                            "type": "integer"
+                        },
+                        {
+                            "metadata": {},
+                            "name": "upperBin",
+                            "nullable": true,
+                            "type": "integer"
+                        },
+                        {
+                            "metadata": {},
+                            "name": "upperBin6",
+                            "nullable": true,
+                            "type": "integer"
+                        }
+                    ],
+                    "type": "struct"
+                },
+                "type": "array"
+            }
+        },
+        {
+            "metadata": {},
+            "name": "tep",
+            "nullable": true,
+            "type": {
+                "fields": [
+                    {
+                        "metadata": {},
+                        "name": "targetFromSourceId",
+                        "nullable": true,
+                        "type": "string"
+                    },
+                    {
+                        "metadata": {},
+                        "name": "description",
+                        "nullable": true,
+                        "type": "string"
+                    },
+                    {
+                        "metadata": {},
+                        "name": "therapeuticArea",
+                        "nullable": true,
+                        "type": "string"
+                    },
+                    {
+                        "metadata": {},
+                        "name": "url",
+                        "nullable": true,
+                        "type": "string"
+                    }
+                ],
+                "type": "struct"
+            }
+        },
+        {
+            "metadata": {},
+            "name": "proteinIds",
+            "nullable": true,
+            "type": {
+                "containsNull": true,
+                "elementType": {
+                    "fields": [
+                        {
+                            "metadata": {},
+                            "name": "id",
+                            "nullable": true,
+                            "type": "string"
+                        },
+                        {
+                            "metadata": {},
+                            "name": "source",
+                            "nullable": true,
+                            "type": "string"
+                        }
+                    ],
+                    "type": "struct"
+                },
+                "type": "array"
+            }
+        },
+        {
+            "metadata": {},
+            "name": "dbXrefs",
+            "nullable": true,
+            "type": {
+                "containsNull": true,
+                "elementType": {
+                    "fields": [
+                        {
+                            "metadata": {},
+                            "name": "id",
+                            "nullable": true,
+                            "type": "string"
+                        },
+                        {
+                            "metadata": {},
+                            "name": "source",
+                            "nullable": true,
+                            "type": "string"
+                        }
+                    ],
+                    "type": "struct"
+                },
+                "type": "array"
+            }
+        },
+        {
+            "metadata": {},
+            "name": "chemicalProbes",
+            "nullable": true,
+            "type": {
+                "containsNull": true,
+                "elementType": {
+                    "fields": [
+                        {
+                            "metadata": {},
+                            "name": "control",
+                            "nullable": true,
+                            "type": "string"
+                        },
+                        {
+                            "metadata": {},
+                            "name": "drugId",
+                            "nullable": true,
+                            "type": "string"
+                        },
+                        {
+                            "metadata": {},
+                            "name": "id",
+                            "nullable": true,
+                            "type": "string"
+                        },
+                        {
+                            "metadata": {},
+                            "name": "isHighQuality",
+                            "nullable": true,
+                            "type": "boolean"
+                        },
+                        {
+                            "metadata": {},
+                            "name": "mechanismOfAction",
+                            "nullable": true,
+                            "type": {
+                                "containsNull": true,
+                                "elementType": "string",
+                                "type": "array"
+                            }
+                        },
+                        {
+                            "metadata": {},
+                            "name": "origin",
+                            "nullable": true,
+                            "type": {
+                                "containsNull": true,
+                                "elementType": "string",
+                                "type": "array"
+                            }
+                        },
+                        {
+                            "metadata": {},
+                            "name": "probeMinerScore",
+                            "nullable": true,
+                            "type": "double"
+                        },
+                        {
+                            "metadata": {},
+                            "name": "probesDrugsScore",
+                            "nullable": true,
+                            "type": "double"
+                        },
+                        {
+                            "metadata": {},
+                            "name": "scoreInCells",
+                            "nullable": true,
+                            "type": "double"
+                        },
+                        {
+                            "metadata": {},
+                            "name": "scoreInOrganisms",
+                            "nullable": true,
+                            "type": "double"
+                        },
+                        {
+                            "metadata": {},
+                            "name": "targetFromSourceId",
+                            "nullable": true,
+                            "type": "string"
+                        },
+                        {
+                            "metadata": {},
+                            "name": "urls",
+                            "nullable": true,
+                            "type": {
+                                "containsNull": true,
+                                "elementType": {
+                                    "fields": [
+                                        {
+                                            "metadata": {},
+                                            "name": "niceName",
+                                            "nullable": true,
+                                            "type": "string"
+                                        },
+                                        {
+                                            "metadata": {},
+                                            "name": "url",
+                                            "nullable": true,
+                                            "type": "string"
+                                        }
+                                    ],
+                                    "type": "struct"
+                                },
+                                "type": "array"
+                            }
+                        }
+                    ],
+                    "type": "struct"
+                },
+                "type": "array"
+            }
+        },
+        {
+            "metadata": {},
+            "name": "homologues",
+            "nullable": true,
+            "type": {
+                "containsNull": true,
+                "elementType": {
+                    "fields": [
+                        {
+                            "metadata": {},
+                            "name": "speciesId",
+                            "nullable": true,
+                            "type": "string"
+                        },
+                        {
+                            "metadata": {},
+                            "name": "speciesName",
+                            "nullable": true,
+                            "type": "string"
+                        },
+                        {
+                            "metadata": {},
+                            "name": "homologyType",
+                            "nullable": true,
+                            "type": "string"
+                        },
+                        {
+                            "metadata": {},
+                            "name": "targetGeneId",
+                            "nullable": true,
+                            "type": "string"
+                        },
+                        {
+                            "metadata": {},
+                            "name": "isHighConfidence",
+                            "nullable": true,
+                            "type": "string"
+                        },
+                        {
+                            "metadata": {},
+                            "name": "targetGeneSymbol",
+                            "nullable": true,
+                            "type": "string"
+                        },
+                        {
+                            "metadata": {},
+                            "name": "queryPercentageIdentity",
+                            "nullable": true,
+                            "type": "double"
+                        },
+                        {
+                            "metadata": {},
+                            "name": "targetPercentageIdentity",
+                            "nullable": true,
+                            "type": "double"
+                        },
+                        {
+                            "metadata": {},
+                            "name": "priority",
+                            "nullable": true,
+                            "type": "integer"
+                        }
+                    ],
+                    "type": "struct"
+                },
+                "type": "array"
+            }
+        },
+        {
+            "metadata": {},
+            "name": "tractability",
+            "nullable": true,
+            "type": {
+                "containsNull": true,
+                "elementType": {
+                    "fields": [
+                        {
+                            "metadata": {},
+                            "name": "modality",
+                            "nullable": true,
+                            "type": "string"
+                        },
+                        {
+                            "metadata": {},
+                            "name": "id",
+                            "nullable": true,
+                            "type": "string"
+                        },
+                        {
+                            "metadata": {},
+                            "name": "value",
+                            "nullable": true,
+                            "type": "boolean"
+                        }
+                    ],
+                    "type": "struct"
+                },
+                "type": "array"
+            }
+        },
+        {
+            "metadata": {},
+            "name": "safetyLiabilities",
+            "nullable": true,
+            "type": {
+                "containsNull": true,
+                "elementType": {
+                    "fields": [
+                        {
+                            "metadata": {},
+                            "name": "event",
+                            "nullable": true,
+                            "type": "string"
+                        },
+                        {
+                            "metadata": {},
+                            "name": "eventId",
+                            "nullable": true,
+                            "type": "string"
+                        },
+                        {
+                            "metadata": {},
+                            "name": "effects",
+                            "nullable": true,
+                            "type": {
+                                "containsNull": true,
+                                "elementType": {
+                                    "fields": [
+                                        {
+                                            "metadata": {},
+                                            "name": "direction",
+                                            "nullable": true,
+                                            "type": "string"
+                                        },
+                                        {
+                                            "metadata": {},
+                                            "name": "dosing",
+                                            "nullable": true,
+                                            "type": "string"
+                                        }
+                                    ],
+                                    "type": "struct"
+                                },
+                                "type": "array"
+                            }
+                        },
+                        {
+                            "metadata": {},
+                            "name": "biosample",
+                            "nullable": true,
+                            "type": {
+                                "containsNull": true,
+                                "elementType": {
+                                    "fields": [
+                                        {
+                                            "metadata": {},
+                                            "name": "tissueLabel",
+                                            "nullable": true,
+                                            "type": "string"
+                                        },
+                                        {
+                                            "metadata": {},
+                                            "name": "tissueId",
+                                            "nullable": true,
+                                            "type": "string"
+                                        },
+                                        {
+                                            "metadata": {},
+                                            "name": "cellLabel",
+                                            "nullable": true,
+                                            "type": "string"
+                                        },
+                                        {
+                                            "metadata": {},
+                                            "name": "cellFormat",
+                                            "nullable": true,
+                                            "type": "string"
+                                        },
+                                        {
+                                            "metadata": {},
+                                            "name": "cellId",
+                                            "nullable": true,
+                                            "type": "string"
+                                        }
+                                    ],
+                                    "type": "struct"
+                                },
+                                "type": "array"
+                            }
+                        },
+                        {
+                            "metadata": {},
+                            "name": "datasource",
+                            "nullable": true,
+                            "type": "string"
+                        },
+                        {
+                            "metadata": {},
+                            "name": "literature",
+                            "nullable": true,
+                            "type": "string"
+                        },
+                        {
+                            "metadata": {},
+                            "name": "url",
+                            "nullable": true,
+                            "type": "string"
+                        },
+                        {
+                            "metadata": {},
+                            "name": "study",
+                            "nullable": true,
+                            "type": {
+                                "containsNull": true,
+                                "elementType": {
+                                    "fields": [
+                                        {
+                                            "metadata": {},
+                                            "name": "name",
+                                            "nullable": true,
+                                            "type": "string"
+                                        },
+                                        {
+                                            "metadata": {},
+                                            "name": "description",
+                                            "nullable": true,
+                                            "type": "string"
+                                        },
+                                        {
+                                            "metadata": {},
+                                            "name": "type",
+                                            "nullable": true,
+                                            "type": "string"
+                                        }
+                                    ],
+                                    "type": "struct"
+                                },
+                                "type": "array"
+                            }
+                        }
+                    ],
+                    "type": "struct"
+                },
+                "type": "array"
+            }
+        },
+        {
+            "metadata": {},
+            "name": "pathways",
+            "nullable": true,
+            "type": {
+                "containsNull": true,
+                "elementType": {
+                    "fields": [
+                        {
+                            "metadata": {},
+                            "name": "pathwayId",
+                            "nullable": true,
+                            "type": "string"
+                        },
+                        {
+                            "metadata": {},
+                            "name": "pathway",
+                            "nullable": true,
+                            "type": "string"
+                        },
+                        {
+                            "metadata": {},
+                            "name": "topLevelTerm",
+                            "nullable": true,
+                            "type": "string"
+                        }
+                    ],
+                    "type": "struct"
+                },
+                "type": "array"
+            }
+        }
+    ],
+    "type": "struct"
+}

--- a/src/etl/json/schemas/targets.json
+++ b/src/etl/json/schemas/targets.json
@@ -1,1025 +1,1025 @@
 {
-    "fields": [
-        {
+  "fields": [
+    {
+      "metadata": {},
+      "name": "id",
+      "nullable": true,
+      "type": "string"
+    },
+    {
+      "metadata": {},
+      "name": "approvedSymbol",
+      "nullable": true,
+      "type": "string"
+    },
+    {
+      "metadata": {},
+      "name": "biotype",
+      "nullable": true,
+      "type": "string"
+    },
+    {
+      "metadata": {},
+      "name": "transcriptIds",
+      "nullable": true,
+      "type": {
+        "containsNull": true,
+        "elementType": "string",
+        "type": "array"
+      }
+    },
+    {
+      "metadata": {},
+      "name": "canonicalTranscript",
+      "nullable": true,
+      "type": {
+        "fields": [
+          {
             "metadata": {},
             "name": "id",
             "nullable": true,
             "type": "string"
-        },
-        {
+          },
+          {
             "metadata": {},
-            "name": "approvedSymbol",
+            "name": "chromosome",
             "nullable": true,
             "type": "string"
-        },
-        {
+          },
+          {
             "metadata": {},
-            "name": "biotype",
+            "name": "start",
+            "nullable": true,
+            "type": "long"
+          },
+          {
+            "metadata": {},
+            "name": "end",
+            "nullable": true,
+            "type": "long"
+          },
+          {
+            "metadata": {},
+            "name": "strand",
             "nullable": true,
             "type": "string"
-        },
-        {
+          }
+        ],
+        "type": "struct"
+      }
+    },
+    {
+      "metadata": {},
+      "name": "canonicalExons",
+      "nullable": true,
+      "type": {
+        "containsNull": true,
+        "elementType": "string",
+        "type": "array"
+      }
+    },
+    {
+      "metadata": {},
+      "name": "genomicLocation",
+      "nullable": true,
+      "type": {
+        "fields": [
+          {
             "metadata": {},
-            "name": "transcriptIds",
-            "nullable": true,
-            "type": {
-                "containsNull": true,
-                "elementType": "string",
-                "type": "array"
-            }
-        },
-        {
-            "metadata": {},
-            "name": "canonicalTranscript",
-            "nullable": true,
-            "type": {
-                "fields": [
-                    {
-                        "metadata": {},
-                        "name": "id",
-                        "nullable": true,
-                        "type": "string"
-                    },
-                    {
-                        "metadata": {},
-                        "name": "chromosome",
-                        "nullable": true,
-                        "type": "string"
-                    },
-                    {
-                        "metadata": {},
-                        "name": "start",
-                        "nullable": true,
-                        "type": "long"
-                    },
-                    {
-                        "metadata": {},
-                        "name": "end",
-                        "nullable": true,
-                        "type": "long"
-                    },
-                    {
-                        "metadata": {},
-                        "name": "strand",
-                        "nullable": true,
-                        "type": "string"
-                    }
-                ],
-                "type": "struct"
-            }
-        },
-        {
-            "metadata": {},
-            "name": "canonicalExons",
-            "nullable": true,
-            "type": {
-                "containsNull": true,
-                "elementType": "string",
-                "type": "array"
-            }
-        },
-        {
-            "metadata": {},
-            "name": "genomicLocation",
-            "nullable": true,
-            "type": {
-                "fields": [
-                    {
-                        "metadata": {},
-                        "name": "chromosome",
-                        "nullable": true,
-                        "type": "string"
-                    },
-                    {
-                        "metadata": {},
-                        "name": "start",
-                        "nullable": true,
-                        "type": "long"
-                    },
-                    {
-                        "metadata": {},
-                        "name": "end",
-                        "nullable": true,
-                        "type": "long"
-                    },
-                    {
-                        "metadata": {},
-                        "name": "strand",
-                        "nullable": true,
-                        "type": "integer"
-                    }
-                ],
-                "type": "struct"
-            }
-        },
-        {
-            "metadata": {},
-            "name": "alternativeGenes",
-            "nullable": true,
-            "type": {
-                "containsNull": true,
-                "elementType": "string",
-                "type": "array"
-            }
-        },
-        {
-            "metadata": {},
-            "name": "approvedName",
+            "name": "chromosome",
             "nullable": true,
             "type": "string"
-        },
-        {
+          },
+          {
             "metadata": {},
-            "name": "go",
+            "name": "start",
             "nullable": true,
-            "type": {
-                "containsNull": true,
-                "elementType": {
-                    "fields": [
-                        {
-                            "metadata": {},
-                            "name": "id",
-                            "nullable": true,
-                            "type": "string"
-                        },
-                        {
-                            "metadata": {},
-                            "name": "source",
-                            "nullable": true,
-                            "type": "string"
-                        },
-                        {
-                            "metadata": {},
-                            "name": "evidence",
-                            "nullable": true,
-                            "type": "string"
-                        },
-                        {
-                            "metadata": {},
-                            "name": "aspect",
-                            "nullable": true,
-                            "type": "string"
-                        },
-                        {
-                            "metadata": {},
-                            "name": "geneProduct",
-                            "nullable": true,
-                            "type": "string"
-                        },
-                        {
-                            "metadata": {},
-                            "name": "ecoId",
-                            "nullable": true,
-                            "type": "string"
-                        }
-                    ],
-                    "type": "struct"
-                },
-                "type": "array"
+            "type": "long"
+          },
+          {
+            "metadata": {},
+            "name": "end",
+            "nullable": true,
+            "type": "long"
+          },
+          {
+            "metadata": {},
+            "name": "strand",
+            "nullable": true,
+            "type": "integer"
+          }
+        ],
+        "type": "struct"
+      }
+    },
+    {
+      "metadata": {},
+      "name": "alternativeGenes",
+      "nullable": true,
+      "type": {
+        "containsNull": true,
+        "elementType": "string",
+        "type": "array"
+      }
+    },
+    {
+      "metadata": {},
+      "name": "approvedName",
+      "nullable": true,
+      "type": "string"
+    },
+    {
+      "metadata": {},
+      "name": "go",
+      "nullable": true,
+      "type": {
+        "containsNull": true,
+        "elementType": {
+          "fields": [
+            {
+              "metadata": {},
+              "name": "id",
+              "nullable": true,
+              "type": "string"
+            },
+            {
+              "metadata": {},
+              "name": "source",
+              "nullable": true,
+              "type": "string"
+            },
+            {
+              "metadata": {},
+              "name": "evidence",
+              "nullable": true,
+              "type": "string"
+            },
+            {
+              "metadata": {},
+              "name": "aspect",
+              "nullable": true,
+              "type": "string"
+            },
+            {
+              "metadata": {},
+              "name": "geneProduct",
+              "nullable": true,
+              "type": "string"
+            },
+            {
+              "metadata": {},
+              "name": "ecoId",
+              "nullable": true,
+              "type": "string"
             }
+          ],
+          "type": "struct"
         },
-        {
+        "type": "array"
+      }
+    },
+    {
+      "metadata": {},
+      "name": "hallmarks",
+      "nullable": true,
+      "type": {
+        "fields": [
+          {
             "metadata": {},
-            "name": "hallmarks",
+            "name": "attributes",
             "nullable": true,
             "type": {
+              "containsNull": true,
+              "elementType": {
                 "fields": [
-                    {
-                        "metadata": {},
-                        "name": "attributes",
-                        "nullable": true,
-                        "type": {
-                            "containsNull": true,
-                            "elementType": {
-                                "fields": [
-                                    {
-                                        "metadata": {},
-                                        "name": "pmid",
-                                        "nullable": true,
-                                        "type": "long"
-                                    },
-                                    {
-                                        "metadata": {},
-                                        "name": "description",
-                                        "nullable": true,
-                                        "type": "string"
-                                    },
-                                    {
-                                        "metadata": {},
-                                        "name": "attribute_name",
-                                        "nullable": true,
-                                        "type": "string"
-                                    }
-                                ],
-                                "type": "struct"
-                            },
-                            "type": "array"
-                        }
-                    },
-                    {
-                        "metadata": {},
-                        "name": "cancerHallmarks",
-                        "nullable": true,
-                        "type": {
-                            "containsNull": true,
-                            "elementType": {
-                                "fields": [
-                                    {
-                                        "metadata": {},
-                                        "name": "pmid",
-                                        "nullable": true,
-                                        "type": "long"
-                                    },
-                                    {
-                                        "metadata": {},
-                                        "name": "description",
-                                        "nullable": true,
-                                        "type": "string"
-                                    },
-                                    {
-                                        "metadata": {},
-                                        "name": "impact",
-                                        "nullable": true,
-                                        "type": "string"
-                                    },
-                                    {
-                                        "metadata": {},
-                                        "name": "label",
-                                        "nullable": true,
-                                        "type": "string"
-                                    }
-                                ],
-                                "type": "struct"
-                            },
-                            "type": "array"
-                        }
-                    }
+                  {
+                    "metadata": {},
+                    "name": "pmid",
+                    "nullable": true,
+                    "type": "long"
+                  },
+                  {
+                    "metadata": {},
+                    "name": "description",
+                    "nullable": true,
+                    "type": "string"
+                  },
+                  {
+                    "metadata": {},
+                    "name": "attribute_name",
+                    "nullable": true,
+                    "type": "string"
+                  }
                 ],
                 "type": "struct"
+              },
+              "type": "array"
             }
-        },
-        {
+          },
+          {
             "metadata": {},
-            "name": "synonyms",
+            "name": "cancerHallmarks",
             "nullable": true,
             "type": {
-                "containsNull": true,
-                "elementType": {
-                    "fields": [
-                        {
-                            "metadata": {},
-                            "name": "label",
-                            "nullable": true,
-                            "type": "string"
-                        },
-                        {
-                            "metadata": {},
-                            "name": "source",
-                            "nullable": true,
-                            "type": "string"
-                        }
-                    ],
-                    "type": "struct"
-                },
-                "type": "array"
+              "containsNull": true,
+              "elementType": {
+                "fields": [
+                  {
+                    "metadata": {},
+                    "name": "pmid",
+                    "nullable": true,
+                    "type": "long"
+                  },
+                  {
+                    "metadata": {},
+                    "name": "description",
+                    "nullable": true,
+                    "type": "string"
+                  },
+                  {
+                    "metadata": {},
+                    "name": "impact",
+                    "nullable": true,
+                    "type": "string"
+                  },
+                  {
+                    "metadata": {},
+                    "name": "label",
+                    "nullable": true,
+                    "type": "string"
+                  }
+                ],
+                "type": "struct"
+              },
+              "type": "array"
             }
-        },
-        {
-            "metadata": {},
-            "name": "symbolSynonyms",
-            "nullable": true,
-            "type": {
-                "containsNull": true,
-                "elementType": {
-                    "fields": [
-                        {
-                            "metadata": {},
-                            "name": "label",
-                            "nullable": true,
-                            "type": "string"
-                        },
-                        {
-                            "metadata": {},
-                            "name": "source",
-                            "nullable": true,
-                            "type": "string"
-                        }
-                    ],
-                    "type": "struct"
-                },
-                "type": "array"
+          }
+        ],
+        "type": "struct"
+      }
+    },
+    {
+      "metadata": {},
+      "name": "synonyms",
+      "nullable": true,
+      "type": {
+        "containsNull": true,
+        "elementType": {
+          "fields": [
+            {
+              "metadata": {},
+              "name": "label",
+              "nullable": true,
+              "type": "string"
+            },
+            {
+              "metadata": {},
+              "name": "source",
+              "nullable": true,
+              "type": "string"
             }
+          ],
+          "type": "struct"
         },
-        {
-            "metadata": {},
-            "name": "nameSynonyms",
-            "nullable": true,
-            "type": {
-                "containsNull": true,
-                "elementType": {
-                    "fields": [
-                        {
-                            "metadata": {},
-                            "name": "label",
-                            "nullable": true,
-                            "type": "string"
-                        },
-                        {
-                            "metadata": {},
-                            "name": "source",
-                            "nullable": true,
-                            "type": "string"
-                        }
-                    ],
-                    "type": "struct"
-                },
-                "type": "array"
+        "type": "array"
+      }
+    },
+    {
+      "metadata": {},
+      "name": "symbolSynonyms",
+      "nullable": true,
+      "type": {
+        "containsNull": true,
+        "elementType": {
+          "fields": [
+            {
+              "metadata": {},
+              "name": "label",
+              "nullable": true,
+              "type": "string"
+            },
+            {
+              "metadata": {},
+              "name": "source",
+              "nullable": true,
+              "type": "string"
             }
+          ],
+          "type": "struct"
         },
-        {
+        "type": "array"
+      }
+    },
+    {
+      "metadata": {},
+      "name": "nameSynonyms",
+      "nullable": true,
+      "type": {
+        "containsNull": true,
+        "elementType": {
+          "fields": [
+            {
+              "metadata": {},
+              "name": "label",
+              "nullable": true,
+              "type": "string"
+            },
+            {
+              "metadata": {},
+              "name": "source",
+              "nullable": true,
+              "type": "string"
+            }
+          ],
+          "type": "struct"
+        },
+        "type": "array"
+      }
+    },
+    {
+      "metadata": {},
+      "name": "functionDescriptions",
+      "nullable": true,
+      "type": {
+        "containsNull": true,
+        "elementType": "string",
+        "type": "array"
+      }
+    },
+    {
+      "metadata": {},
+      "name": "subcellularLocations",
+      "nullable": true,
+      "type": {
+        "containsNull": true,
+        "elementType": {
+          "fields": [
+            {
+              "metadata": {},
+              "name": "location",
+              "nullable": true,
+              "type": "string"
+            },
+            {
+              "metadata": {},
+              "name": "source",
+              "nullable": true,
+              "type": "string"
+            },
+            {
+              "metadata": {},
+              "name": "termSL",
+              "nullable": true,
+              "type": "string"
+            },
+            {
+              "metadata": {},
+              "name": "labelSL",
+              "nullable": true,
+              "type": "string"
+            }
+          ],
+          "type": "struct"
+        },
+        "type": "array"
+      }
+    },
+    {
+      "metadata": {},
+      "name": "targetClass",
+      "nullable": true,
+      "type": {
+        "containsNull": true,
+        "elementType": {
+          "fields": [
+            {
+              "metadata": {},
+              "name": "id",
+              "nullable": true,
+              "type": "long"
+            },
+            {
+              "metadata": {},
+              "name": "label",
+              "nullable": true,
+              "type": "string"
+            },
+            {
+              "metadata": {},
+              "name": "level",
+              "nullable": true,
+              "type": "string"
+            }
+          ],
+          "type": "struct"
+        },
+        "type": "array"
+      }
+    },
+    {
+      "metadata": {},
+      "name": "obsoleteSymbols",
+      "nullable": true,
+      "type": {
+        "containsNull": true,
+        "elementType": {
+          "fields": [
+            {
+              "metadata": {},
+              "name": "label",
+              "nullable": true,
+              "type": "string"
+            },
+            {
+              "metadata": {},
+              "name": "source",
+              "nullable": true,
+              "type": "string"
+            }
+          ],
+          "type": "struct"
+        },
+        "type": "array"
+      }
+    },
+    {
+      "metadata": {},
+      "name": "obsoleteNames",
+      "nullable": true,
+      "type": {
+        "containsNull": true,
+        "elementType": {
+          "fields": [
+            {
+              "metadata": {},
+              "name": "label",
+              "nullable": true,
+              "type": "string"
+            },
+            {
+              "metadata": {},
+              "name": "source",
+              "nullable": true,
+              "type": "string"
+            }
+          ],
+          "type": "struct"
+        },
+        "type": "array"
+      }
+    },
+    {
+      "metadata": {},
+      "name": "constraint",
+      "nullable": true,
+      "type": {
+        "containsNull": true,
+        "elementType": {
+          "fields": [
+            {
+              "metadata": {},
+              "name": "constraintType",
+              "nullable": true,
+              "type": "string"
+            },
+            {
+              "metadata": {},
+              "name": "score",
+              "nullable": true,
+              "type": "float"
+            },
+            {
+              "metadata": {},
+              "name": "exp",
+              "nullable": true,
+              "type": "float"
+            },
+            {
+              "metadata": {},
+              "name": "obs",
+              "nullable": true,
+              "type": "integer"
+            },
+            {
+              "metadata": {},
+              "name": "oe",
+              "nullable": true,
+              "type": "float"
+            },
+            {
+              "metadata": {},
+              "name": "oeLower",
+              "nullable": true,
+              "type": "float"
+            },
+            {
+              "metadata": {},
+              "name": "oeUpper",
+              "nullable": true,
+              "type": "float"
+            },
+            {
+              "metadata": {},
+              "name": "upperRank",
+              "nullable": true,
+              "type": "integer"
+            },
+            {
+              "metadata": {},
+              "name": "upperBin",
+              "nullable": true,
+              "type": "integer"
+            },
+            {
+              "metadata": {},
+              "name": "upperBin6",
+              "nullable": true,
+              "type": "integer"
+            }
+          ],
+          "type": "struct"
+        },
+        "type": "array"
+      }
+    },
+    {
+      "metadata": {},
+      "name": "tep",
+      "nullable": true,
+      "type": {
+        "fields": [
+          {
             "metadata": {},
-            "name": "functionDescriptions",
+            "name": "targetFromSourceId",
             "nullable": true,
-            "type": {
+            "type": "string"
+          },
+          {
+            "metadata": {},
+            "name": "description",
+            "nullable": true,
+            "type": "string"
+          },
+          {
+            "metadata": {},
+            "name": "therapeuticArea",
+            "nullable": true,
+            "type": "string"
+          },
+          {
+            "metadata": {},
+            "name": "url",
+            "nullable": true,
+            "type": "string"
+          }
+        ],
+        "type": "struct"
+      }
+    },
+    {
+      "metadata": {},
+      "name": "proteinIds",
+      "nullable": true,
+      "type": {
+        "containsNull": true,
+        "elementType": {
+          "fields": [
+            {
+              "metadata": {},
+              "name": "id",
+              "nullable": true,
+              "type": "string"
+            },
+            {
+              "metadata": {},
+              "name": "source",
+              "nullable": true,
+              "type": "string"
+            }
+          ],
+          "type": "struct"
+        },
+        "type": "array"
+      }
+    },
+    {
+      "metadata": {},
+      "name": "dbXrefs",
+      "nullable": true,
+      "type": {
+        "containsNull": true,
+        "elementType": {
+          "fields": [
+            {
+              "metadata": {},
+              "name": "id",
+              "nullable": true,
+              "type": "string"
+            },
+            {
+              "metadata": {},
+              "name": "source",
+              "nullable": true,
+              "type": "string"
+            }
+          ],
+          "type": "struct"
+        },
+        "type": "array"
+      }
+    },
+    {
+      "metadata": {},
+      "name": "chemicalProbes",
+      "nullable": true,
+      "type": {
+        "containsNull": true,
+        "elementType": {
+          "fields": [
+            {
+              "metadata": {},
+              "name": "control",
+              "nullable": true,
+              "type": "string"
+            },
+            {
+              "metadata": {},
+              "name": "drugId",
+              "nullable": true,
+              "type": "string"
+            },
+            {
+              "metadata": {},
+              "name": "id",
+              "nullable": true,
+              "type": "string"
+            },
+            {
+              "metadata": {},
+              "name": "isHighQuality",
+              "nullable": true,
+              "type": "boolean"
+            },
+            {
+              "metadata": {},
+              "name": "mechanismOfAction",
+              "nullable": true,
+              "type": {
                 "containsNull": true,
                 "elementType": "string",
                 "type": "array"
-            }
-        },
-        {
-            "metadata": {},
-            "name": "subcellularLocations",
-            "nullable": true,
-            "type": {
+              }
+            },
+            {
+              "metadata": {},
+              "name": "origin",
+              "nullable": true,
+              "type": {
+                "containsNull": true,
+                "elementType": "string",
+                "type": "array"
+              }
+            },
+            {
+              "metadata": {},
+              "name": "probeMinerScore",
+              "nullable": true,
+              "type": "double"
+            },
+            {
+              "metadata": {},
+              "name": "probesDrugsScore",
+              "nullable": true,
+              "type": "double"
+            },
+            {
+              "metadata": {},
+              "name": "scoreInCells",
+              "nullable": true,
+              "type": "double"
+            },
+            {
+              "metadata": {},
+              "name": "scoreInOrganisms",
+              "nullable": true,
+              "type": "double"
+            },
+            {
+              "metadata": {},
+              "name": "targetFromSourceId",
+              "nullable": true,
+              "type": "string"
+            },
+            {
+              "metadata": {},
+              "name": "urls",
+              "nullable": true,
+              "type": {
                 "containsNull": true,
                 "elementType": {
-                    "fields": [
-                        {
-                            "metadata": {},
-                            "name": "location",
-                            "nullable": true,
-                            "type": "string"
-                        },
-                        {
-                            "metadata": {},
-                            "name": "source",
-                            "nullable": true,
-                            "type": "string"
-                        },
-                        {
-                            "metadata": {},
-                            "name": "termSL",
-                            "nullable": true,
-                            "type": "string"
-                        },
-                        {
-                            "metadata": {},
-                            "name": "labelSL",
-                            "nullable": true,
-                            "type": "string"
-                        }
-                    ],
-                    "type": "struct"
-                },
-                "type": "array"
-            }
-        },
-        {
-            "metadata": {},
-            "name": "targetClass",
-            "nullable": true,
-            "type": {
-                "containsNull": true,
-                "elementType": {
-                    "fields": [
-                        {
-                            "metadata": {},
-                            "name": "id",
-                            "nullable": true,
-                            "type": "long"
-                        },
-                        {
-                            "metadata": {},
-                            "name": "label",
-                            "nullable": true,
-                            "type": "string"
-                        },
-                        {
-                            "metadata": {},
-                            "name": "level",
-                            "nullable": true,
-                            "type": "string"
-                        }
-                    ],
-                    "type": "struct"
-                },
-                "type": "array"
-            }
-        },
-        {
-            "metadata": {},
-            "name": "obsoleteSymbols",
-            "nullable": true,
-            "type": {
-                "containsNull": true,
-                "elementType": {
-                    "fields": [
-                        {
-                            "metadata": {},
-                            "name": "label",
-                            "nullable": true,
-                            "type": "string"
-                        },
-                        {
-                            "metadata": {},
-                            "name": "source",
-                            "nullable": true,
-                            "type": "string"
-                        }
-                    ],
-                    "type": "struct"
-                },
-                "type": "array"
-            }
-        },
-        {
-            "metadata": {},
-            "name": "obsoleteNames",
-            "nullable": true,
-            "type": {
-                "containsNull": true,
-                "elementType": {
-                    "fields": [
-                        {
-                            "metadata": {},
-                            "name": "label",
-                            "nullable": true,
-                            "type": "string"
-                        },
-                        {
-                            "metadata": {},
-                            "name": "source",
-                            "nullable": true,
-                            "type": "string"
-                        }
-                    ],
-                    "type": "struct"
-                },
-                "type": "array"
-            }
-        },
-        {
-            "metadata": {},
-            "name": "constraint",
-            "nullable": true,
-            "type": {
-                "containsNull": true,
-                "elementType": {
-                    "fields": [
-                        {
-                            "metadata": {},
-                            "name": "constraintType",
-                            "nullable": true,
-                            "type": "string"
-                        },
-                        {
-                            "metadata": {},
-                            "name": "score",
-                            "nullable": true,
-                            "type": "float"
-                        },
-                        {
-                            "metadata": {},
-                            "name": "exp",
-                            "nullable": true,
-                            "type": "float"
-                        },
-                        {
-                            "metadata": {},
-                            "name": "obs",
-                            "nullable": true,
-                            "type": "integer"
-                        },
-                        {
-                            "metadata": {},
-                            "name": "oe",
-                            "nullable": true,
-                            "type": "float"
-                        },
-                        {
-                            "metadata": {},
-                            "name": "oeLower",
-                            "nullable": true,
-                            "type": "float"
-                        },
-                        {
-                            "metadata": {},
-                            "name": "oeUpper",
-                            "nullable": true,
-                            "type": "float"
-                        },
-                        {
-                            "metadata": {},
-                            "name": "upperRank",
-                            "nullable": true,
-                            "type": "integer"
-                        },
-                        {
-                            "metadata": {},
-                            "name": "upperBin",
-                            "nullable": true,
-                            "type": "integer"
-                        },
-                        {
-                            "metadata": {},
-                            "name": "upperBin6",
-                            "nullable": true,
-                            "type": "integer"
-                        }
-                    ],
-                    "type": "struct"
-                },
-                "type": "array"
-            }
-        },
-        {
-            "metadata": {},
-            "name": "tep",
-            "nullable": true,
-            "type": {
-                "fields": [
+                  "fields": [
                     {
-                        "metadata": {},
-                        "name": "targetFromSourceId",
-                        "nullable": true,
-                        "type": "string"
+                      "metadata": {},
+                      "name": "niceName",
+                      "nullable": true,
+                      "type": "string"
                     },
                     {
-                        "metadata": {},
-                        "name": "description",
-                        "nullable": true,
-                        "type": "string"
-                    },
-                    {
-                        "metadata": {},
-                        "name": "therapeuticArea",
-                        "nullable": true,
-                        "type": "string"
-                    },
-                    {
-                        "metadata": {},
-                        "name": "url",
-                        "nullable": true,
-                        "type": "string"
+                      "metadata": {},
+                      "name": "url",
+                      "nullable": true,
+                      "type": "string"
                     }
-                ],
-                "type": "struct"
-            }
-        },
-        {
-            "metadata": {},
-            "name": "proteinIds",
-            "nullable": true,
-            "type": {
-                "containsNull": true,
-                "elementType": {
-                    "fields": [
-                        {
-                            "metadata": {},
-                            "name": "id",
-                            "nullable": true,
-                            "type": "string"
-                        },
-                        {
-                            "metadata": {},
-                            "name": "source",
-                            "nullable": true,
-                            "type": "string"
-                        }
-                    ],
-                    "type": "struct"
+                  ],
+                  "type": "struct"
                 },
                 "type": "array"
+              }
             }
+          ],
+          "type": "struct"
         },
-        {
-            "metadata": {},
-            "name": "dbXrefs",
-            "nullable": true,
-            "type": {
+        "type": "array"
+      }
+    },
+    {
+      "metadata": {},
+      "name": "homologues",
+      "nullable": true,
+      "type": {
+        "containsNull": true,
+        "elementType": {
+          "fields": [
+            {
+              "metadata": {},
+              "name": "speciesId",
+              "nullable": true,
+              "type": "string"
+            },
+            {
+              "metadata": {},
+              "name": "speciesName",
+              "nullable": true,
+              "type": "string"
+            },
+            {
+              "metadata": {},
+              "name": "homologyType",
+              "nullable": true,
+              "type": "string"
+            },
+            {
+              "metadata": {},
+              "name": "targetGeneId",
+              "nullable": true,
+              "type": "string"
+            },
+            {
+              "metadata": {},
+              "name": "isHighConfidence",
+              "nullable": true,
+              "type": "string"
+            },
+            {
+              "metadata": {},
+              "name": "targetGeneSymbol",
+              "nullable": true,
+              "type": "string"
+            },
+            {
+              "metadata": {},
+              "name": "queryPercentageIdentity",
+              "nullable": true,
+              "type": "double"
+            },
+            {
+              "metadata": {},
+              "name": "targetPercentageIdentity",
+              "nullable": true,
+              "type": "double"
+            },
+            {
+              "metadata": {},
+              "name": "priority",
+              "nullable": true,
+              "type": "integer"
+            }
+          ],
+          "type": "struct"
+        },
+        "type": "array"
+      }
+    },
+    {
+      "metadata": {},
+      "name": "tractability",
+      "nullable": true,
+      "type": {
+        "containsNull": true,
+        "elementType": {
+          "fields": [
+            {
+              "metadata": {},
+              "name": "modality",
+              "nullable": true,
+              "type": "string"
+            },
+            {
+              "metadata": {},
+              "name": "id",
+              "nullable": true,
+              "type": "string"
+            },
+            {
+              "metadata": {},
+              "name": "value",
+              "nullable": true,
+              "type": "boolean"
+            }
+          ],
+          "type": "struct"
+        },
+        "type": "array"
+      }
+    },
+    {
+      "metadata": {},
+      "name": "safetyLiabilities",
+      "nullable": true,
+      "type": {
+        "containsNull": true,
+        "elementType": {
+          "fields": [
+            {
+              "metadata": {},
+              "name": "event",
+              "nullable": true,
+              "type": "string"
+            },
+            {
+              "metadata": {},
+              "name": "eventId",
+              "nullable": true,
+              "type": "string"
+            },
+            {
+              "metadata": {},
+              "name": "effects",
+              "nullable": true,
+              "type": {
                 "containsNull": true,
                 "elementType": {
-                    "fields": [
-                        {
-                            "metadata": {},
-                            "name": "id",
-                            "nullable": true,
-                            "type": "string"
-                        },
-                        {
-                            "metadata": {},
-                            "name": "source",
-                            "nullable": true,
-                            "type": "string"
-                        }
-                    ],
-                    "type": "struct"
+                  "fields": [
+                    {
+                      "metadata": {},
+                      "name": "direction",
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    {
+                      "metadata": {},
+                      "name": "dosing",
+                      "nullable": true,
+                      "type": "string"
+                    }
+                  ],
+                  "type": "struct"
                 },
                 "type": "array"
-            }
-        },
-        {
-            "metadata": {},
-            "name": "chemicalProbes",
-            "nullable": true,
-            "type": {
+              }
+            },
+            {
+              "metadata": {},
+              "name": "biosample",
+              "nullable": true,
+              "type": {
                 "containsNull": true,
                 "elementType": {
-                    "fields": [
-                        {
-                            "metadata": {},
-                            "name": "control",
-                            "nullable": true,
-                            "type": "string"
-                        },
-                        {
-                            "metadata": {},
-                            "name": "drugId",
-                            "nullable": true,
-                            "type": "string"
-                        },
-                        {
-                            "metadata": {},
-                            "name": "id",
-                            "nullable": true,
-                            "type": "string"
-                        },
-                        {
-                            "metadata": {},
-                            "name": "isHighQuality",
-                            "nullable": true,
-                            "type": "boolean"
-                        },
-                        {
-                            "metadata": {},
-                            "name": "mechanismOfAction",
-                            "nullable": true,
-                            "type": {
-                                "containsNull": true,
-                                "elementType": "string",
-                                "type": "array"
-                            }
-                        },
-                        {
-                            "metadata": {},
-                            "name": "origin",
-                            "nullable": true,
-                            "type": {
-                                "containsNull": true,
-                                "elementType": "string",
-                                "type": "array"
-                            }
-                        },
-                        {
-                            "metadata": {},
-                            "name": "probeMinerScore",
-                            "nullable": true,
-                            "type": "double"
-                        },
-                        {
-                            "metadata": {},
-                            "name": "probesDrugsScore",
-                            "nullable": true,
-                            "type": "double"
-                        },
-                        {
-                            "metadata": {},
-                            "name": "scoreInCells",
-                            "nullable": true,
-                            "type": "double"
-                        },
-                        {
-                            "metadata": {},
-                            "name": "scoreInOrganisms",
-                            "nullable": true,
-                            "type": "double"
-                        },
-                        {
-                            "metadata": {},
-                            "name": "targetFromSourceId",
-                            "nullable": true,
-                            "type": "string"
-                        },
-                        {
-                            "metadata": {},
-                            "name": "urls",
-                            "nullable": true,
-                            "type": {
-                                "containsNull": true,
-                                "elementType": {
-                                    "fields": [
-                                        {
-                                            "metadata": {},
-                                            "name": "niceName",
-                                            "nullable": true,
-                                            "type": "string"
-                                        },
-                                        {
-                                            "metadata": {},
-                                            "name": "url",
-                                            "nullable": true,
-                                            "type": "string"
-                                        }
-                                    ],
-                                    "type": "struct"
-                                },
-                                "type": "array"
-                            }
-                        }
-                    ],
-                    "type": "struct"
+                  "fields": [
+                    {
+                      "metadata": {},
+                      "name": "tissueLabel",
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    {
+                      "metadata": {},
+                      "name": "tissueId",
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    {
+                      "metadata": {},
+                      "name": "cellLabel",
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    {
+                      "metadata": {},
+                      "name": "cellFormat",
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    {
+                      "metadata": {},
+                      "name": "cellId",
+                      "nullable": true,
+                      "type": "string"
+                    }
+                  ],
+                  "type": "struct"
                 },
                 "type": "array"
-            }
-        },
-        {
-            "metadata": {},
-            "name": "homologues",
-            "nullable": true,
-            "type": {
+              }
+            },
+            {
+              "metadata": {},
+              "name": "datasource",
+              "nullable": true,
+              "type": "string"
+            },
+            {
+              "metadata": {},
+              "name": "literature",
+              "nullable": true,
+              "type": "string"
+            },
+            {
+              "metadata": {},
+              "name": "url",
+              "nullable": true,
+              "type": "string"
+            },
+            {
+              "metadata": {},
+              "name": "study",
+              "nullable": true,
+              "type": {
                 "containsNull": true,
                 "elementType": {
-                    "fields": [
-                        {
-                            "metadata": {},
-                            "name": "speciesId",
-                            "nullable": true,
-                            "type": "string"
-                        },
-                        {
-                            "metadata": {},
-                            "name": "speciesName",
-                            "nullable": true,
-                            "type": "string"
-                        },
-                        {
-                            "metadata": {},
-                            "name": "homologyType",
-                            "nullable": true,
-                            "type": "string"
-                        },
-                        {
-                            "metadata": {},
-                            "name": "targetGeneId",
-                            "nullable": true,
-                            "type": "string"
-                        },
-                        {
-                            "metadata": {},
-                            "name": "isHighConfidence",
-                            "nullable": true,
-                            "type": "string"
-                        },
-                        {
-                            "metadata": {},
-                            "name": "targetGeneSymbol",
-                            "nullable": true,
-                            "type": "string"
-                        },
-                        {
-                            "metadata": {},
-                            "name": "queryPercentageIdentity",
-                            "nullable": true,
-                            "type": "double"
-                        },
-                        {
-                            "metadata": {},
-                            "name": "targetPercentageIdentity",
-                            "nullable": true,
-                            "type": "double"
-                        },
-                        {
-                            "metadata": {},
-                            "name": "priority",
-                            "nullable": true,
-                            "type": "integer"
-                        }
-                    ],
-                    "type": "struct"
+                  "fields": [
+                    {
+                      "metadata": {},
+                      "name": "name",
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    {
+                      "metadata": {},
+                      "name": "description",
+                      "nullable": true,
+                      "type": "string"
+                    },
+                    {
+                      "metadata": {},
+                      "name": "type",
+                      "nullable": true,
+                      "type": "string"
+                    }
+                  ],
+                  "type": "struct"
                 },
                 "type": "array"
+              }
             }
+          ],
+          "type": "struct"
         },
-        {
-            "metadata": {},
-            "name": "tractability",
-            "nullable": true,
-            "type": {
-                "containsNull": true,
-                "elementType": {
-                    "fields": [
-                        {
-                            "metadata": {},
-                            "name": "modality",
-                            "nullable": true,
-                            "type": "string"
-                        },
-                        {
-                            "metadata": {},
-                            "name": "id",
-                            "nullable": true,
-                            "type": "string"
-                        },
-                        {
-                            "metadata": {},
-                            "name": "value",
-                            "nullable": true,
-                            "type": "boolean"
-                        }
-                    ],
-                    "type": "struct"
-                },
-                "type": "array"
+        "type": "array"
+      }
+    },
+    {
+      "metadata": {},
+      "name": "pathways",
+      "nullable": true,
+      "type": {
+        "containsNull": true,
+        "elementType": {
+          "fields": [
+            {
+              "metadata": {},
+              "name": "pathwayId",
+              "nullable": true,
+              "type": "string"
+            },
+            {
+              "metadata": {},
+              "name": "pathway",
+              "nullable": true,
+              "type": "string"
+            },
+            {
+              "metadata": {},
+              "name": "topLevelTerm",
+              "nullable": true,
+              "type": "string"
             }
+          ],
+          "type": "struct"
         },
-        {
-            "metadata": {},
-            "name": "safetyLiabilities",
-            "nullable": true,
-            "type": {
-                "containsNull": true,
-                "elementType": {
-                    "fields": [
-                        {
-                            "metadata": {},
-                            "name": "event",
-                            "nullable": true,
-                            "type": "string"
-                        },
-                        {
-                            "metadata": {},
-                            "name": "eventId",
-                            "nullable": true,
-                            "type": "string"
-                        },
-                        {
-                            "metadata": {},
-                            "name": "effects",
-                            "nullable": true,
-                            "type": {
-                                "containsNull": true,
-                                "elementType": {
-                                    "fields": [
-                                        {
-                                            "metadata": {},
-                                            "name": "direction",
-                                            "nullable": true,
-                                            "type": "string"
-                                        },
-                                        {
-                                            "metadata": {},
-                                            "name": "dosing",
-                                            "nullable": true,
-                                            "type": "string"
-                                        }
-                                    ],
-                                    "type": "struct"
-                                },
-                                "type": "array"
-                            }
-                        },
-                        {
-                            "metadata": {},
-                            "name": "biosample",
-                            "nullable": true,
-                            "type": {
-                                "containsNull": true,
-                                "elementType": {
-                                    "fields": [
-                                        {
-                                            "metadata": {},
-                                            "name": "tissueLabel",
-                                            "nullable": true,
-                                            "type": "string"
-                                        },
-                                        {
-                                            "metadata": {},
-                                            "name": "tissueId",
-                                            "nullable": true,
-                                            "type": "string"
-                                        },
-                                        {
-                                            "metadata": {},
-                                            "name": "cellLabel",
-                                            "nullable": true,
-                                            "type": "string"
-                                        },
-                                        {
-                                            "metadata": {},
-                                            "name": "cellFormat",
-                                            "nullable": true,
-                                            "type": "string"
-                                        },
-                                        {
-                                            "metadata": {},
-                                            "name": "cellId",
-                                            "nullable": true,
-                                            "type": "string"
-                                        }
-                                    ],
-                                    "type": "struct"
-                                },
-                                "type": "array"
-                            }
-                        },
-                        {
-                            "metadata": {},
-                            "name": "datasource",
-                            "nullable": true,
-                            "type": "string"
-                        },
-                        {
-                            "metadata": {},
-                            "name": "literature",
-                            "nullable": true,
-                            "type": "string"
-                        },
-                        {
-                            "metadata": {},
-                            "name": "url",
-                            "nullable": true,
-                            "type": "string"
-                        },
-                        {
-                            "metadata": {},
-                            "name": "study",
-                            "nullable": true,
-                            "type": {
-                                "containsNull": true,
-                                "elementType": {
-                                    "fields": [
-                                        {
-                                            "metadata": {},
-                                            "name": "name",
-                                            "nullable": true,
-                                            "type": "string"
-                                        },
-                                        {
-                                            "metadata": {},
-                                            "name": "description",
-                                            "nullable": true,
-                                            "type": "string"
-                                        },
-                                        {
-                                            "metadata": {},
-                                            "name": "type",
-                                            "nullable": true,
-                                            "type": "string"
-                                        }
-                                    ],
-                                    "type": "struct"
-                                },
-                                "type": "array"
-                            }
-                        }
-                    ],
-                    "type": "struct"
-                },
-                "type": "array"
-            }
-        },
-        {
-            "metadata": {},
-            "name": "pathways",
-            "nullable": true,
-            "type": {
-                "containsNull": true,
-                "elementType": {
-                    "fields": [
-                        {
-                            "metadata": {},
-                            "name": "pathwayId",
-                            "nullable": true,
-                            "type": "string"
-                        },
-                        {
-                            "metadata": {},
-                            "name": "pathway",
-                            "nullable": true,
-                            "type": "string"
-                        },
-                        {
-                            "metadata": {},
-                            "name": "topLevelTerm",
-                            "nullable": true,
-                            "type": "string"
-                        }
-                    ],
-                    "type": "struct"
-                },
-                "type": "array"
-            }
-        }
-    ],
-    "type": "struct"
+        "type": "array"
+      }
+    }
+  ],
+  "type": "struct"
 }

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from pyspark.sql.types import StructType
+
+from etl.json import SCHEMA_DIR
+
+if TYPE_CHECKING:
+    from pytest import Metafunc
+
+
+def pytest_generate_tests(metafunc: Metafunc) -> None:
+    schemas = [f for f in os.listdir(SCHEMA_DIR) if f.endswith(".json")]
+    metafunc.parametrize("schema_json", schemas)
+
+
+def test_schema(schema_json: str) -> None:
+    core_schema = json.loads(Path(SCHEMA_DIR, schema_json).read_text(encoding="utf-8"))
+    isinstance(StructType.fromJson(core_schema), StructType)


### PR DESCRIPTION
1. New `json/schemas` directory stores relevant Spark DataFrame schemas 
2. `read_parquet` in `ETLSession` allows providing schema from the directory when reading a DataFrame
3. `validate_df_schema` validates a DataFrame complies with a given schema from the directory
4. pytest ensures all schemas in the directory are valid Spark schemas