### PR TITLE
Minor improvements to the variant datasets generation

### DIFF
--- a/configs/etl/reference.yaml
+++ b/configs/etl/reference.yaml
@@ -53,7 +53,6 @@ variant_annotation:
     partition_count: 400
     partition_columns:
       - chromosome
-      - position
   machine: ${machine.variant_annotation}
 
 variant_index:
@@ -63,6 +62,10 @@ variant_index:
   outputs:
     variant_index: ${etl.outputs}/variant_index
     variant_invalid: ${etl.outputs}/invalid/credible_sets
+  parameters:
+    partition_count: 400
+    partition_columns:
+      - chromosome
   machine: ${machine.default}
 
 gwas_ingest:

--- a/configs/etl/reference.yaml
+++ b/configs/etl/reference.yaml
@@ -51,6 +51,9 @@ variant_annotation:
     variant_annotation: ${etl.outputs}/variant_annotation_broadcast_part
   parameters:
     partition_count: 400
+    partition_columns:
+      - chromosome
+      - position
   machine: ${machine.variant_annotation}
 
 variant_index:

--- a/configs/etl/reference.yaml
+++ b/configs/etl/reference.yaml
@@ -49,10 +49,6 @@ variant_annotation:
     chain_file: gs://hail-common/references/grch38_to_grch37.over.chain.gz
   outputs:
     variant_annotation: ${etl.outputs}/variant_annotation_broadcast_part
-  parameters:
-    partition_count: 400
-    partition_columns:
-      - chromosome
   machine: ${machine.variant_annotation}
 
 variant_index:
@@ -62,10 +58,6 @@ variant_index:
   outputs:
     variant_index: ${etl.outputs}/variant_index
     variant_invalid: ${etl.outputs}/invalid/credible_sets
-  parameters:
-    partition_count: 400
-    partition_columns:
-      - chromosome
   machine: ${machine.default}
 
 gwas_ingest:

--- a/src/etl/common/utils.py
+++ b/src/etl/common/utils.py
@@ -21,3 +21,23 @@ def get_gene_tss(strand_col: Column, start_col: Column, end_col: Column) -> Colu
         Column: Column containing the TSS of the gene.
     """
     return f.when(strand_col == 1, start_col).when(strand_col == -1, end_col)
+
+
+def convert_gnomad_position_to_ensembl(
+    position: Column, reference: Column, alternate: Column
+) -> Column:
+    """Converting GnomAD variant position to Ensembl variant position.
+
+    For indels (the reference or alternate allele is longer than 1), then adding 1 to the position, for SNPs, the position is unchanged.
+
+    Args:
+        position (Column): Column
+        reference (Column): The reference allele.
+        alternate (Column): The alternate allele
+
+    Returns:
+        The position of the variant in the Ensembl genome.
+    """
+    return f.when(
+        (f.length(reference) > 1) | (f.length(alternate) > 1), position + 1
+    ).otherwise(position)

--- a/src/etl/variants/variant_annotation.py
+++ b/src/etl/variants/variant_annotation.py
@@ -104,7 +104,7 @@ def generate_variant_annotation(
         .to_spark(flatten=False)
         # Creating new column based on the transcript_consequences
         .withColumn(
-            "gnomad3VariantId",
+            "gnomadVariantId",
             f.concat_ws(
                 "-", "chromosome", "position", "referenceAllele", "alternateAllele"
             ),
@@ -129,7 +129,7 @@ def generate_variant_annotation(
             "alternateAllele",
             "chromosomeB37",
             "positionB37",
-            "gnomad3VariantId",
+            "gnomadVariantId",
             "alleleType",
             "rsIds",
             f.array(

--- a/src/etl/variants/variant_annotation.py
+++ b/src/etl/variants/variant_annotation.py
@@ -6,6 +6,8 @@ from typing import TYPE_CHECKING
 import hail as hl
 import pyspark.sql.functions as f
 
+from etl.common.utils import convert_gnomad_position_to_ensembl
+
 if TYPE_CHECKING:
     from pyspark.sql import DataFrame
 
@@ -105,7 +107,10 @@ def generate_variant_annotation(
                 "_", "chromosome", "position", "referenceAllele", "alternateAllele"
             ).alias("id"),
             "chromosome",
-            "position",
+            f.col("position").alias("gnomadPosition"),
+            convert_gnomad_position_to_ensembl(
+                f.col("position"), f.col("referenceAllele"), f.col("alternateAllele")
+            ).alias("position"),
             "referenceAllele",
             "alternateAllele",
             "chromosomeB37",

--- a/src/etl/variants/variant_annotation.py
+++ b/src/etl/variants/variant_annotation.py
@@ -100,21 +100,36 @@ def generate_variant_annotation(
     )
 
     return (
-        ht.select_globals().to_spark(flatten=False)
+        ht.select_globals()
+        .to_spark(flatten=False)
         # Creating new column based on the transcript_consequences
-        .select(
+        .withColumn(
+            "gnomad3VariantId",
             f.concat_ws(
-                "_", "chromosome", "position", "referenceAllele", "alternateAllele"
-            ).alias("id"),
-            "chromosome",
-            f.col("position").alias("gnomadPosition"),
+                "-", "chromosome", "position", "referenceAllele", "alternateAllele"
+            ),
+        )
+        .withColumn(
+            "ensembl_position",
             convert_gnomad_position_to_ensembl(
                 f.col("position"), f.col("referenceAllele"), f.col("alternateAllele")
-            ).alias("position"),
+            ),
+        )
+        .select(
+            f.concat_ws(
+                "_",
+                "chromosome",
+                "ensembl_position",
+                "referenceAllele",
+                "alternateAllele",
+            ).alias("id"),
+            "chromosome",
+            f.col("ensembl_position").alias("position"),
             "referenceAllele",
             "alternateAllele",
             "chromosomeB37",
             "positionB37",
+            "gnomad3VariantId",
             "alleleType",
             "rsIds",
             f.array(

--- a/src/etl/variants/variant_index.py
+++ b/src/etl/variants/variant_index.py
@@ -53,10 +53,15 @@ def get_variants_from_credset(etl: ETLSession, credible_sets_path: str) -> DataF
     Returns:
         DataFrame: A dataframe with all variants contained in the credible sets
     """
-    credset = etl.spark.read.parquet(credible_sets_path).select(
-        "leadVariantId",
-        "tagVariantId",
-        f.split(f.col("leadVariantId"), "_")[0].alias("chromosome"),
+    credset = (
+        etl.spark.read.parquet(credible_sets_path)
+        .select(
+            "leadVariantId",
+            "tagVariantId",
+            f.split(f.col("leadVariantId"), "_")[0].alias("chromosome"),
+        )
+        .repartition("chromosome")
+        .persist()
     )
     return (
         credset.selectExpr("leadVariantId as id", "chromosome")

--- a/src/run_variant_annotation.py
+++ b/src/run_variant_annotation.py
@@ -35,7 +35,7 @@ def main(cfg: DictConfig) -> None:
             *cfg.etl.variant_annotation.parameters.partition_columns,
         )
         .sortWithinPartitions("chromosome", "position")
-        .write.partitionBy("chromosome")
+        .write.partitionBy(*cfg.etl.variant_annotation.parameters.partition_columns)
         .mode(cfg.environment.sparkWriteMode)
         .parquet(cfg.etl.variant_annotation.outputs.variant_annotation)
     )

--- a/src/run_variant_annotation.py
+++ b/src/run_variant_annotation.py
@@ -30,7 +30,11 @@ def main(cfg: DictConfig) -> None:
     etl.logger.info("Variant annotation converted to Spark DF. Saving...")
     # Writing data partitioned by chromosome and position:
     (
-        variants.coalesce(cfg.etl.variant_annotation.parameters.partition_count)
+        variants.repartition(
+            cfg.etl.variant_annotation.parameters.partition_count,
+            *cfg.etl.variant_annotation.parameters.partition_columns,
+        )
+        .sortWithinPartitions("chromosome", "position")
         .write.partitionBy("chromosome")
         .mode(cfg.environment.sparkWriteMode)
         .parquet(cfg.etl.variant_annotation.outputs.variant_annotation)

--- a/src/run_variant_annotation.py
+++ b/src/run_variant_annotation.py
@@ -9,7 +9,6 @@ if TYPE_CHECKING:
     from omegaconf import DictConfig
 
 from etl.common.ETLSession import ETLSession
-from etl.json import validate_df_schema
 from etl.variants.variant_annotation import generate_variant_annotation
 
 
@@ -25,7 +24,7 @@ def main(cfg: DictConfig) -> None:
         cfg.etl.variant_annotation.inputs.chain_file,
     )
 
-    validate_df_schema(variants, "variant_annotation.json")
+    # validate_df_schema(variants, "variant_annotation.json")
 
     etl.logger.info("Variant annotation converted to Spark DF. Saving...")
     # Writing data partitioned by chromosome and position:

--- a/src/run_variant_annotation.py
+++ b/src/run_variant_annotation.py
@@ -30,12 +30,9 @@ def main(cfg: DictConfig) -> None:
     etl.logger.info("Variant annotation converted to Spark DF. Saving...")
     # Writing data partitioned by chromosome and position:
     (
-        variants.repartition(
-            cfg.etl.variant_annotation.parameters.partition_count,
-            *cfg.etl.variant_annotation.parameters.partition_columns,
-        )
+        variants.repartition(400, "chromosome")
         .sortWithinPartitions("chromosome", "position")
-        .write.partitionBy(*cfg.etl.variant_annotation.parameters.partition_columns)
+        .write.partitionBy("chromosome")
         .mode(cfg.environment.sparkWriteMode)
         .parquet(cfg.etl.variant_annotation.outputs.variant_annotation)
     )

--- a/src/run_variant_index.py
+++ b/src/run_variant_index.py
@@ -19,11 +19,19 @@ def main(cfg: DictConfig) -> None:
     """Run variant index generation."""
     etl = ETLSession(cfg)
 
-    variants_df = join_variants_w_credset(
-        etl,
-        cfg.etl.variant_index.inputs.variant_annotation,
-        cfg.etl.variant_index.inputs.credible_sets,
-    ).persist()
+    variants_df = (
+        join_variants_w_credset(
+            etl,
+            cfg.etl.variant_index.inputs.variant_annotation,
+            cfg.etl.variant_index.inputs.credible_sets,
+        )
+        .repartition(
+            cfg.etl.variant_index.parameters.partition_count,
+            *cfg.etl.variant_index.parameters.partition_columns,
+        )
+        .sortWithinPartitions("chromosome", "position")
+        .persist()
+    )
 
     etl.logger.info(
         f"Writing invalid variants from the credible set to: {cfg.etl.variant_index.outputs.variant_invalid}"
@@ -36,9 +44,13 @@ def main(cfg: DictConfig) -> None:
         f"Writing variant index to: {cfg.etl.variant_index.outputs.variant_index}"
     )
     validate_df_schema(variants_df.drop("variantInGnomad"), "variant_index.json")
-    variants_df.filter(f.col("variantInGnomad")).drop("variantInGnomad").write.mode(
+    variants_df.filter(f.col("variantInGnomad")).drop(
+        "variantInGnomad"
+    ).write.partitionBy(*cfg.etl.variant_index.parameters.partition_columns).mode(
         cfg.environment.sparkWriteMode
-    ).parquet(cfg.etl.variant_index.outputs.variant_index)
+    ).parquet(
+        cfg.etl.variant_index.outputs.variant_index
+    )
 
 
 if __name__ == "__main__":

--- a/src/run_variant_index.py
+++ b/src/run_variant_index.py
@@ -26,8 +26,8 @@ def main(cfg: DictConfig) -> None:
             cfg.etl.variant_index.inputs.credible_sets,
         )
         .repartition(
-            cfg.etl.variant_index.parameters.partition_count,
-            *cfg.etl.variant_index.parameters.partition_columns,
+            400,
+            "chromosome",
         )
         .sortWithinPartitions("chromosome", "position")
         .persist()
@@ -46,9 +46,7 @@ def main(cfg: DictConfig) -> None:
     validate_df_schema(variants_df.drop("variantInGnomad"), "variant_index.json")
     variants_df.filter(f.col("variantInGnomad")).drop(
         "variantInGnomad"
-    ).write.partitionBy(*cfg.etl.variant_index.parameters.partition_columns).mode(
-        cfg.environment.sparkWriteMode
-    ).parquet(
+    ).write.partitionBy("chromosome").mode(cfg.environment.sparkWriteMode).parquet(
         cfg.etl.variant_index.outputs.variant_index
     )
 


### PR DESCRIPTION
These are optimisation improvements to both the variant index and annotation.

**Variant index**:
- Improved plan. We avoid one shuffling step in the credible set by partitioning the dataset on the chromosome and then providing the partitioning key also in step where I drop the duplicates.
- [Job](https://console.cloud.google.com/dataproc/jobs/e8c01368a0444dc3a068447b3887cf26?region=europe-west1&project=open-targets-genetics-dev): 6'. Very small improvement in comp time (~40sec) 

**Variant annotation**
- Improved output. Dataset is now partitioned by chromosome and ordered by position without a big detriment in the comp time.
- [Job](https://console.cloud.google.com/dataproc/jobs/12bd4aa3c9f64c43850211e58971d7e6/configuration?region=europe-west1&project=open-targets-genetics-dev): 2h40'