### PR TITLE
Do va slim

### DIFF
--- a/src/otg/assets/schemas/colocalisation.json
+++ b/src/otg/assets/schemas/colocalisation.json
@@ -4,13 +4,13 @@
     {
       "name": "left_studyLocusId",
       "nullable": false,
-      "type": "string",
+      "type": "long",
       "metadata": {}
     },
     {
       "name": "right_studyLocusId",
       "nullable": false,
-      "type": "string",
+      "type": "long",
       "metadata": {}
     },
     {

--- a/src/otg/assets/schemas/study_locus.json
+++ b/src/otg/assets/schemas/study_locus.json
@@ -4,7 +4,7 @@
       "metadata": {},
       "name": "studyLocusId",
       "nullable": false,
-      "type": "string"
+      "type": "long"
     },
     {
       "metadata": {},
@@ -70,13 +70,13 @@
       "metadata": {},
       "name": "pValueMantissa",
       "nullable": true,
-      "type": "double"
+      "type": "float"
     },
     {
       "metadata": {},
       "name": "pValueExponent",
       "nullable": true,
-      "type": "long"
+      "type": "integer"
     },
     {
       "metadata": {},
@@ -89,7 +89,7 @@
       "type": {
         "type": "array",
         "elementType": "string",
-        "containsNull": true
+        "containsNull": false
       },
       "nullable": true,
       "metadata": {}

--- a/src/otg/assets/schemas/study_locus_overlap.json
+++ b/src/otg/assets/schemas/study_locus_overlap.json
@@ -4,13 +4,13 @@
       "metadata": {},
       "name": "left_studyLocusId",
       "nullable": false,
-      "type": "string"
+      "type": "long"
     },
     {
       "metadata": {},
       "name": "right_studyLocusId",
       "nullable": false,
-      "type": "string"
+      "type": "long"
     },
     {
       "metadata": {},

--- a/src/otg/assets/schemas/variant_annotation.json
+++ b/src/otg/assets/schemas/variant_annotation.json
@@ -73,20 +73,20 @@
           "type": "struct",
           "fields": [
             {
-              "name": "alleleFrequency",
-              "type": "double",
+              "name": "populationName",
+              "type": "string",
               "nullable": true,
               "metadata": {}
             },
             {
-              "name": "populationName",
-              "type": "string",
-              "nullable": false,
+              "name": "alleleFrequency",
+              "type": "double",
+              "nullable": true,
               "metadata": {}
             }
           ]
         },
-        "containsNull": false
+        "containsNull": true
       },
       "nullable": false,
       "metadata": {}
@@ -160,19 +160,13 @@
                     "metadata": {}
                   },
                   {
-                    "name": "polyphenPrediction",
-                    "type": "string",
-                    "nullable": true,
-                    "metadata": {}
-                  },
-                  {
                     "name": "polyphenScore",
                     "type": "double",
                     "nullable": true,
                     "metadata": {}
                   },
                   {
-                    "name": "siftPrediction",
+                    "name": "polyphenPrediction",
                     "type": "string",
                     "nullable": true,
                     "metadata": {}
@@ -180,6 +174,12 @@
                   {
                     "name": "siftScore",
                     "type": "double",
+                    "nullable": true,
+                    "metadata": {}
+                  },
+                  {
+                    "name": "siftPrediction",
+                    "type": "string",
                     "nullable": true,
                     "metadata": {}
                   }

--- a/src/otg/assets/schemas/variant_annotation.json
+++ b/src/otg/assets/schemas/variant_annotation.json
@@ -10,13 +10,13 @@
     {
       "name": "chromosome",
       "type": "string",
-      "nullable": true,
+      "nullable": false,
       "metadata": {}
     },
     {
       "name": "position",
       "type": "integer",
-      "nullable": true,
+      "nullable": false,
       "metadata": {}
     },
     {
@@ -28,13 +28,13 @@
     {
       "name": "referenceAllele",
       "type": "string",
-      "nullable": true,
+      "nullable": false,
       "metadata": {}
     },
     {
       "name": "alternateAllele",
       "type": "string",
-      "nullable": true,
+      "nullable": false,
       "metadata": {}
     },
     {
@@ -125,150 +125,6 @@
             "metadata": {}
           },
           {
-            "name": "motifFeatureConsequences",
-            "type": {
-              "type": "array",
-              "elementType": {
-                "type": "struct",
-                "fields": [
-                  {
-                    "name": "allele_num",
-                    "type": "integer",
-                    "nullable": true,
-                    "metadata": {}
-                  },
-                  {
-                    "name": "consequence_terms",
-                    "type": {
-                      "type": "array",
-                      "elementType": "string",
-                      "containsNull": true
-                    },
-                    "nullable": true,
-                    "metadata": {}
-                  },
-                  {
-                    "name": "high_inf_pos",
-                    "type": "string",
-                    "nullable": true,
-                    "metadata": {}
-                  },
-                  {
-                    "name": "impact",
-                    "type": "string",
-                    "nullable": true,
-                    "metadata": {}
-                  },
-                  {
-                    "name": "minimised",
-                    "type": "integer",
-                    "nullable": true,
-                    "metadata": {}
-                  },
-                  {
-                    "name": "motif_feature_id",
-                    "type": "string",
-                    "nullable": true,
-                    "metadata": {}
-                  },
-                  {
-                    "name": "motif_name",
-                    "type": "string",
-                    "nullable": true,
-                    "metadata": {}
-                  },
-                  {
-                    "name": "motif_pos",
-                    "type": "integer",
-                    "nullable": true,
-                    "metadata": {}
-                  },
-                  {
-                    "name": "motif_score_change",
-                    "type": "double",
-                    "nullable": true,
-                    "metadata": {}
-                  },
-                  {
-                    "name": "strand",
-                    "type": "integer",
-                    "nullable": true,
-                    "metadata": {}
-                  },
-                  {
-                    "name": "variant_allele",
-                    "type": "string",
-                    "nullable": true,
-                    "metadata": {}
-                  }
-                ]
-              },
-              "containsNull": true
-            },
-            "nullable": true,
-            "metadata": {}
-          },
-          {
-            "name": "regulatoryFeatureConsequences",
-            "type": {
-              "type": "array",
-              "elementType": {
-                "type": "struct",
-                "fields": [
-                  {
-                    "name": "allele_num",
-                    "type": "integer",
-                    "nullable": true,
-                    "metadata": {}
-                  },
-                  {
-                    "name": "biotype",
-                    "type": "string",
-                    "nullable": true,
-                    "metadata": {}
-                  },
-                  {
-                    "name": "consequence_terms",
-                    "type": {
-                      "type": "array",
-                      "elementType": "string",
-                      "containsNull": true
-                    },
-                    "nullable": true,
-                    "metadata": {}
-                  },
-                  {
-                    "name": "impact",
-                    "type": "string",
-                    "nullable": true,
-                    "metadata": {}
-                  },
-                  {
-                    "name": "minimised",
-                    "type": "integer",
-                    "nullable": true,
-                    "metadata": {}
-                  },
-                  {
-                    "name": "regulatory_feature_id",
-                    "type": "string",
-                    "nullable": true,
-                    "metadata": {}
-                  },
-                  {
-                    "name": "variant_allele",
-                    "type": "string",
-                    "nullable": true,
-                    "metadata": {}
-                  }
-                ]
-              },
-              "containsNull": true
-            },
-            "nullable": true,
-            "metadata": {}
-          },
-          {
             "name": "transcriptConsequences",
             "type": {
               "type": "array",
@@ -276,73 +132,13 @@
                 "type": "struct",
                 "fields": [
                   {
-                    "name": "allele_num",
-                    "type": "integer",
-                    "nullable": true,
-                    "metadata": {}
-                  },
-                  {
-                    "name": "amino_acids",
+                    "name": "aminoAcids",
                     "type": "string",
                     "nullable": true,
                     "metadata": {}
                   },
                   {
-                    "name": "appris",
-                    "type": "string",
-                    "nullable": true,
-                    "metadata": {}
-                  },
-                  {
-                    "name": "biotype",
-                    "type": "string",
-                    "nullable": true,
-                    "metadata": {}
-                  },
-                  {
-                    "name": "canonical",
-                    "type": "integer",
-                    "nullable": true,
-                    "metadata": {}
-                  },
-                  {
-                    "name": "ccds",
-                    "type": "string",
-                    "nullable": true,
-                    "metadata": {}
-                  },
-                  {
-                    "name": "cdna_start",
-                    "type": "integer",
-                    "nullable": true,
-                    "metadata": {}
-                  },
-                  {
-                    "name": "cdna_end",
-                    "type": "integer",
-                    "nullable": true,
-                    "metadata": {}
-                  },
-                  {
-                    "name": "cds_end",
-                    "type": "integer",
-                    "nullable": true,
-                    "metadata": {}
-                  },
-                  {
-                    "name": "cds_start",
-                    "type": "integer",
-                    "nullable": true,
-                    "metadata": {}
-                  },
-                  {
-                    "name": "codons",
-                    "type": "string",
-                    "nullable": true,
-                    "metadata": {}
-                  },
-                  {
-                    "name": "consequence_terms",
+                    "name": "consequenceTerms",
                     "type": {
                       "type": "array",
                       "elementType": "string",
@@ -352,99 +148,7 @@
                     "metadata": {}
                   },
                   {
-                    "name": "distance",
-                    "type": "integer",
-                    "nullable": true,
-                    "metadata": {}
-                  },
-                  {
-                    "name": "domains",
-                    "type": {
-                      "type": "array",
-                      "elementType": {
-                        "type": "struct",
-                        "fields": [
-                          {
-                            "name": "db",
-                            "type": "string",
-                            "nullable": true,
-                            "metadata": {}
-                          },
-                          {
-                            "name": "name",
-                            "type": "string",
-                            "nullable": true,
-                            "metadata": {}
-                          }
-                        ]
-                      },
-                      "containsNull": true
-                    },
-                    "nullable": true,
-                    "metadata": {}
-                  },
-                  {
-                    "name": "exon",
-                    "type": "string",
-                    "nullable": true,
-                    "metadata": {}
-                  },
-                  {
-                    "name": "gene_id",
-                    "type": "string",
-                    "nullable": true,
-                    "metadata": {}
-                  },
-                  {
-                    "name": "gene_pheno",
-                    "type": "integer",
-                    "nullable": true,
-                    "metadata": {}
-                  },
-                  {
-                    "name": "gene_symbol",
-                    "type": "string",
-                    "nullable": true,
-                    "metadata": {}
-                  },
-                  {
-                    "name": "gene_symbol_source",
-                    "type": "string",
-                    "nullable": true,
-                    "metadata": {}
-                  },
-                  {
-                    "name": "hgnc_id",
-                    "type": "string",
-                    "nullable": true,
-                    "metadata": {}
-                  },
-                  {
-                    "name": "hgvsc",
-                    "type": "string",
-                    "nullable": true,
-                    "metadata": {}
-                  },
-                  {
-                    "name": "hgvsp",
-                    "type": "string",
-                    "nullable": true,
-                    "metadata": {}
-                  },
-                  {
-                    "name": "hgvs_offset",
-                    "type": "integer",
-                    "nullable": true,
-                    "metadata": {}
-                  },
-                  {
-                    "name": "impact",
-                    "type": "string",
-                    "nullable": true,
-                    "metadata": {}
-                  },
-                  {
-                    "name": "intron",
+                    "name": "geneId",
                     "type": "string",
                     "nullable": true,
                     "metadata": {}
@@ -456,110 +160,26 @@
                     "metadata": {}
                   },
                   {
-                    "name": "lof_flags",
+                    "name": "polyphenPrediction",
                     "type": "string",
                     "nullable": true,
                     "metadata": {}
                   },
                   {
-                    "name": "lof_filter",
-                    "type": "string",
-                    "nullable": true,
-                    "metadata": {}
-                  },
-                  {
-                    "name": "lof_info",
-                    "type": "string",
-                    "nullable": true,
-                    "metadata": {}
-                  },
-                  {
-                    "name": "minimised",
-                    "type": "integer",
-                    "nullable": true,
-                    "metadata": {}
-                  },
-                  {
-                    "name": "polyphen_prediction",
-                    "type": "string",
-                    "nullable": true,
-                    "metadata": {}
-                  },
-                  {
-                    "name": "polyphen_score",
+                    "name": "polyphenScore",
                     "type": "double",
                     "nullable": true,
                     "metadata": {}
                   },
                   {
-                    "name": "protein_end",
-                    "type": "integer",
-                    "nullable": true,
-                    "metadata": {}
-                  },
-                  {
-                    "name": "protein_start",
-                    "type": "integer",
-                    "nullable": true,
-                    "metadata": {}
-                  },
-                  {
-                    "name": "protein_id",
+                    "name": "siftPrediction",
                     "type": "string",
                     "nullable": true,
                     "metadata": {}
                   },
                   {
-                    "name": "sift_prediction",
-                    "type": "string",
-                    "nullable": true,
-                    "metadata": {}
-                  },
-                  {
-                    "name": "sift_score",
+                    "name": "siftScore",
                     "type": "double",
-                    "nullable": true,
-                    "metadata": {}
-                  },
-                  {
-                    "name": "strand",
-                    "type": "integer",
-                    "nullable": true,
-                    "metadata": {}
-                  },
-                  {
-                    "name": "swissprot",
-                    "type": "string",
-                    "nullable": true,
-                    "metadata": {}
-                  },
-                  {
-                    "name": "transcript_id",
-                    "type": "string",
-                    "nullable": true,
-                    "metadata": {}
-                  },
-                  {
-                    "name": "trembl",
-                    "type": "string",
-                    "nullable": true,
-                    "metadata": {}
-                  },
-                  {
-                    "name": "tsl",
-                    "type": "integer",
-                    "nullable": true,
-                    "metadata": {}
-                  },
-                  {
-                    "name": "uniparc",
-                    "type": "string",
-                    "nullable": true,
-                    "metadata": {}
-                  },
-                  {
-                    "name": "variant_allele",
-                    "type": "string",
                     "nullable": true,
                     "metadata": {}
                   }
@@ -573,16 +193,6 @@
         ]
       },
       "nullable": false,
-      "metadata": {}
-    },
-    {
-      "name": "filters",
-      "type": {
-        "type": "array",
-        "elementType": "string",
-        "containsNull": true
-      },
-      "nullable": true,
       "metadata": {}
     }
   ]

--- a/src/otg/assets/schemas/variant_index.json
+++ b/src/otg/assets/schemas/variant_index.json
@@ -57,20 +57,20 @@
           "type": "struct",
           "fields": [
             {
-              "name": "alleleFrequency",
-              "type": "double",
+              "name": "populationName",
+              "type": "string",
               "nullable": true,
               "metadata": {}
             },
             {
-              "name": "populationName",
-              "type": "string",
-              "nullable": false,
+              "name": "alleleFrequency",
+              "type": "double",
+              "nullable": true,
               "metadata": {}
             }
           ]
         },
-        "containsNull": false
+        "containsNull": true
       },
       "nullable": false,
       "metadata": {}

--- a/src/otg/assets/schemas/variant_index.json
+++ b/src/otg/assets/schemas/variant_index.json
@@ -65,14 +65,14 @@
             {
               "name": "populationName",
               "type": "string",
-              "nullable": true,
+              "nullable": false,
               "metadata": {}
             }
           ]
         },
-        "containsNull": true
+        "containsNull": false
       },
-      "nullable": true,
+      "nullable": false,
       "metadata": {}
     },
     {
@@ -100,16 +100,6 @@
     {
       "name": "mostSevereConsequence",
       "type": "string",
-      "nullable": true,
-      "metadata": {}
-    },
-    {
-      "name": "filters",
-      "type": {
-        "type": "array",
-        "elementType": "string",
-        "containsNull": true
-      },
       "nullable": true,
       "metadata": {}
     },

--- a/src/otg/dataset/study_locus.py
+++ b/src/otg/dataset/study_locus.py
@@ -552,7 +552,7 @@ class StudyLocusGWASCatalog(StudyLocus):
         """Add variant metadata in associations.
 
         Args:
-            gwas_associations (DataFrame): raw GWAS Catalog associations
+            gwas_associations (DataFrame): raw GWAS Catalog associations with additional `studyLocusId` column
             variant_annotation (VariantAnnotation): variant annotation dataset
 
         Returns:

--- a/src/otg/dataset/variant_annotation.py
+++ b/src/otg/dataset/variant_annotation.py
@@ -116,8 +116,8 @@ class VariantAnnotation(Dataset):
                     rsIds=ht.rsid,
                     alleleType=ht.allele_info.allele_type,
                     cadd=hl.struct(
-                        raw=ht.cadd.raw_score,
                         phred=ht.cadd.phred,
+                        raw=ht.cadd.raw_score,
                     ),
                     alleleFrequencies=hl.set([f"{pop}-adj" for pop in populations]).map(
                         lambda p: hl.struct(

--- a/src/otg/dataset/variant_index.py
+++ b/src/otg/dataset/variant_index.py
@@ -65,9 +65,7 @@ class VariantIndex(Dataset):
                 *unchanged_cols,
                 f.col("vep.mostSevereConsequence").alias("mostSevereConsequence"),
                 # filters/rsid are arrays that can be empty, in this case we convert them to null
-                nullify_empty_array(f.col("filters")).alias("filters"),
                 nullify_empty_array(f.col("rsIds")).alias("rsIds"),
-                f.lit(True).alias("variantInGnomad"),
             ),
         )
         return VariantIndex(

--- a/tests/dataset/test_study_locus.py
+++ b/tests/dataset/test_study_locus.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING
 
 import pyspark.sql.functions as f
 from pyspark.sql import Column, DataFrame
+from pyspark.sql.types import LongType
 
 from otg.dataset.study_locus import (
     CredibleInterval,
@@ -32,7 +33,7 @@ def test_study_locus_gwas_catalog_from_source(
         StudyLocusGWASCatalog.from_source(
             sample_gwas_catalog_associations, mock_variant_annotation
         ),
-        DataFrame,
+        StudyLocusGWASCatalog,
     )
 
 
@@ -44,7 +45,7 @@ def test__map_to_variant_annotation_variants(
     assert isinstance(
         StudyLocusGWASCatalog._map_to_variant_annotation_variants(
             sample_gwas_catalog_associations.withColumn(
-                "studyLocusId", f.monotonically_increasing_id()
+                "studyLocusId", f.monotonically_increasing_id().cast(LongType())
             ),
             mock_variant_annotation,
         ),

--- a/tests/dataset/test_study_locus.py
+++ b/tests/dataset/test_study_locus.py
@@ -32,7 +32,23 @@ def test_study_locus_gwas_catalog_from_source(
         StudyLocusGWASCatalog.from_source(
             sample_gwas_catalog_associations, mock_variant_annotation
         ),
-        StudyLocusGWASCatalog,
+        DataFrame,
+    )
+
+
+def test__map_to_variant_annotation_variants(
+    sample_gwas_catalog_associations: DataFrame,
+    mock_variant_annotation: VariantAnnotation,
+) -> None:
+    """Test mapping to variant annotation variants."""
+    assert isinstance(
+        StudyLocusGWASCatalog._map_to_variant_annotation_variants(
+            sample_gwas_catalog_associations.withColumn(
+                "studyLocusId", f.monotonically_increasing_id()
+            ),
+            mock_variant_annotation,
+        ),
+        DataFrame,
     )
 
 

--- a/tests/dataset/test_study_locus.py
+++ b/tests/dataset/test_study_locus.py
@@ -15,11 +15,25 @@ from otg.dataset.study_locus import (
 
 if TYPE_CHECKING:
     from otg.dataset.study_index import StudyIndex, StudyIndexGWASCatalog
+    from otg.dataset.variant_annotation import VariantAnnotation
 
 
 def test_study_locus_creation(mock_study_locus: StudyLocus) -> None:
     """Test study locus creation with mock data."""
     assert isinstance(mock_study_locus, StudyLocus)
+
+
+def test_study_locus_gwas_catalog_from_source(
+    mock_variant_annotation: VariantAnnotation,
+    sample_gwas_catalog_associations: DataFrame,
+) -> None:
+    """Test study locus from gwas catalog mock data."""
+    assert isinstance(
+        StudyLocusGWASCatalog.from_source(
+            sample_gwas_catalog_associations, mock_variant_annotation
+        ),
+        StudyLocusGWASCatalog,
+    )
 
 
 def test_study_locus_gwas_catalog_creation(

--- a/tests/dataset/test_variant_annotation.py
+++ b/tests/dataset/test_variant_annotation.py
@@ -1,0 +1,43 @@
+"""Tests variant annotation dataset."""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from otg.dataset.gene_index import GeneIndex
+
+from otg.dataset.v2g import V2G
+from otg.dataset.variant_annotation import VariantAnnotation
+
+
+def test_variant_index_creation(mock_variant_annotation: VariantAnnotation) -> None:
+    """Test gene index creation with mock gene index."""
+    assert isinstance(mock_variant_annotation, VariantAnnotation)
+
+
+def test_get_polyphen_v2g(
+    mock_variant_annotation: VariantAnnotation, mock_gene_index: GeneIndex
+) -> None:
+    """Test get_polyphen_v2g with mock variant annotation."""
+    assert isinstance(mock_variant_annotation.get_polyphen_v2g(mock_gene_index), V2G)
+
+
+def test_get_sift_v2g(
+    mock_variant_annotation: VariantAnnotation, mock_gene_index: GeneIndex
+) -> None:
+    """Test get_sift_v2g with mock variant annotation."""
+    assert isinstance(mock_variant_annotation.get_sift_v2g(mock_gene_index), V2G)
+
+
+def test_get_plof_v2g(
+    mock_variant_annotation: VariantAnnotation, mock_gene_index: GeneIndex
+) -> None:
+    """Test get_plof_v2g with mock variant annotation."""
+    assert isinstance(mock_variant_annotation.get_plof_v2g(mock_gene_index), V2G)
+
+
+def test_get_distance_to_tss(
+    mock_variant_annotation: VariantAnnotation, mock_gene_index: GeneIndex
+) -> None:
+    """Test get_distance_to_tss with mock variant annotation."""
+    assert isinstance(mock_variant_annotation.get_distance_to_tss(mock_gene_index), V2G)

--- a/tests/dataset/test_variant_index.py
+++ b/tests/dataset/test_variant_index.py
@@ -1,9 +1,20 @@
 """Tests on effect harmonisation."""
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from otg.dataset.variant_index import VariantIndex
+
+if TYPE_CHECKING:
+    from otg.dataset.variant_annotation import VariantAnnotation
 
 
 def test_variant_index_creation(mock_variant_index: VariantIndex) -> None:
     """Test gene index creation with mock gene index."""
     assert isinstance(mock_variant_index, VariantIndex)
+
+
+def test_from_variant_annotation(mock_variant_annotation: VariantAnnotation) -> None:
+    """Test variant index creation from variant annotation."""
+    variant_index = VariantIndex.from_variant_annotation(mock_variant_annotation)
+    assert isinstance(variant_index, VariantIndex)


### PR DESCRIPTION
Variant annotation streamlining:
- updated function to extract information from Hail
- updated schema
- new mock variant annotation dataset
- new tests using variant annotation mock
- fixes associated with newly introduced tests

To circumvent issues on schema validation, the order of some of the fields in the schema needed to be adjusted. Hopefully we could resolve this in the validation so the order of the (nested) schema fields is not relevant. 