### PR TITLE
Test session streamline

### DIFF
--- a/src/conftest.py
+++ b/src/conftest.py
@@ -21,6 +21,25 @@ def spark(doctest_namespace: dict[str, Any]) -> SparkSession:
         SparkSession: local spark session
     """
     # init spark session
-    spark = SparkSession.builder.getOrCreate()
+    spark = (
+        SparkSession.builder.master("local[1]")
+        # no shuffling
+        .config("spark.sql.shuffle.partitions", "1")
+        # ui settings
+        .config("spark.ui.showConsoleProgress", "false")
+        .config("spark.ui.enabled", "false")
+        .config("spark.ui.dagGraph.retainedRootRDDs", "1")
+        .config("spark.ui.retainedJobs", "1")
+        .config("spark.ui.retainedStages", "1")
+        .config("spark.ui.retainedTasks", "1")
+        .config("spark.sql.ui.retainedExecutions", "1")
+        .config("spark.worker.ui.retainedExecutors", "1")
+        .config("spark.worker.ui.retainedDrivers", "1")
+        # fixed memory
+        .config("spark.driver.memory", "2g")
+        .appName("test")
+        .getOrCreate()
+    )
+
     doctest_namespace["spark"] = spark
     return spark

--- a/src/otg/dataset/study_locus.py
+++ b/src/otg/dataset/study_locus.py
@@ -704,10 +704,10 @@ class StudyLocusGWASCatalog(StudyLocus):
         +-------------+------+------------+
         |            1| false|        true|
         |            1| false|        true|
-        |            3|  true|        true|
-        |            3|  true|        true|
         |            2| false|       false|
         |            2|  true|        true|
+        |            3|  true|        true|
+        |            3|  true|        true|
         +-------------+------+------------+
         <BLANKLINE>
 

--- a/src/otg/method/ld.py
+++ b/src/otg/method/ld.py
@@ -197,11 +197,11 @@ class LDAnnotatorGnomad:
             +-------+---------+------------+----------------+
             |studyId|variantId|tagVariantId|flag_to_keep_tag|
             +-------+---------+------------+----------------+
-            |study_1|   lead_3|        null|            true|
             |study_1|   lead_1|       tag_1|            true|
             |study_1|   lead_1|       tag_2|            true|
             |study_1|   lead_2|       tag_3|            true|
             |study_1|   lead_2|        null|           false|
+            |study_1|   lead_3|        null|            true|
             +-------+---------+------------+----------------+
             <BLANKLINE>
         """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,7 +27,21 @@ def spark() -> SparkSession:
     """
     return (
         SparkSession.builder.config("spark.driver.bindAddress", "127.0.0.1")
-        .master("local")
+        .master("local[1]")
+        # no shuffling
+        .config("spark.sql.shuffle.partitions", "1")
+        # ui settings
+        .config("spark.ui.showConsoleProgress", "false")
+        .config("spark.ui.enabled", "false")
+        .config("spark.ui.dagGraph.retainedRootRDDs", "1")
+        .config("spark.ui.retainedJobs", "1")
+        .config("spark.ui.retainedStages", "1")
+        .config("spark.ui.retainedTasks", "1")
+        .config("spark.sql.ui.retainedExecutions", "1")
+        .config("spark.worker.ui.retainedExecutors", "1")
+        .config("spark.worker.ui.retainedDrivers", "1")
+        # fixed memory
+        .config("spark.driver.memory", "2g")
         .appName("test")
         .getOrCreate()
     )


### PR DESCRIPTION
Testing sessions are now configured to run as single-threaded operations and other optimisations to minimise the cost of initialising the spark session. This change also ensures that data frames are not shuffled making it easier to test the expected outputs. (This was otherwise failing when changing python/spark functions)