### PR TITLE
Debugging GWAS Catalog pipeline

### DIFF
--- a/config/datasets/gcp.yaml
+++ b/config/datasets/gcp.yaml
@@ -36,7 +36,7 @@ catalog_study_index: ${datasets.outputs}/catalog_study_index
 catalog_study_locus: ${datasets.outputs}/catalog_study_locus
 finngen_study_index: ${datasets.outputs}/finngen_study_index
 #templates
-ld_index_template: ${datasets.outputs}/gnomad_r2.1.1.{POP}.common.ld.variant_indices.parquet
+ld_index_template: ${datasets.outputs}/ld_indices/gnomad_r2.1.1.{POP}.common.ld.variant_indices
 finngen_release_prefix: FINNGEN_R8_
 finngen_sumstat_url_prefix: https://storage.googleapis.com/finngen-public-data-r8/summary_stats/finngen_R8_
 finngen_sumstat_url_suffix: .gz

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "otgenetics"
-version = "0.1.4.2"
+version = "0.1.4"
 description = "Open targets Genetics Portal Python ETL"
 authors = ["Open Targets core team"]
 license = "Apache License v2"

--- a/src/otg/common/spark_helpers.py
+++ b/src/otg/common/spark_helpers.py
@@ -263,3 +263,20 @@ def column2camel_case(col_name: str) -> str:
         '`hello_world` as helloWorld'
     """
     return f"`{col_name}` as {string2camelcase(col_name)}"
+
+
+def order_array_of_structs_by_field(column_name: str, field_name: str) -> Column:
+    """Sort a column of array of structs by a field in descending order, nulls last."""
+    return f.expr(
+        f"""
+        array_sort(
+        {column_name},
+        (left, right) -> case
+                        when left.{field_name} is null then 1
+                        when right.{field_name} is null then -1
+                        when left.{field_name} < right.{field_name} then 1
+                        when left.{field_name} > right.{field_name} then -1
+                        else 0
+                end)
+        """
+    )

--- a/src/otg/dataset/study_index.py
+++ b/src/otg/dataset/study_index.py
@@ -355,7 +355,7 @@ class StudyIndexGWASCatalog(StudyIndex):
             StudyIndexGWASCatalog: including `summarystatsLocation` and `hasSumstats` columns
         """
         gwas_sumstats_base_uri = (
-            "ftp://ftp.ebi.ac.uk/pub/databases/gwas/summary_statistics"
+            "ftp://ftp.ebi.ac.uk/pub/databases/gwas/summary_statistics/"
         )
 
         parsed_sumstats_lut = sumstats_lut.withColumn(

--- a/src/otg/dataset/study_locus.py
+++ b/src/otg/dataset/study_locus.py
@@ -306,7 +306,6 @@ class StudyLocus(Dataset):
                 "variantId",
                 "studyId",
                 "gnomadPopulation",
-                "chromosome",
                 "relativeSampleSize",
             )
             .distinct()

--- a/src/otg/dataset/study_locus.py
+++ b/src/otg/dataset/study_locus.py
@@ -1531,7 +1531,7 @@ class StudyLocusGWASCatalog(StudyLocus):
             ld_index_template,
             ld_matrix_template,
             min_r2,
-        ).repartition(400, "chromosome", "variantId", "gnomadPopulation")
+        ).coalesce(400)
 
         ld_set = (
             self.unique_study_locus_ancestries(studies)

--- a/src/otg/dataset/study_locus.py
+++ b/src/otg/dataset/study_locus.py
@@ -304,6 +304,7 @@ class StudyLocus(Dataset):
             .filter(f.col("position").isNotNull())
             .select(
                 "variantId",
+                "chromosome",
                 "studyId",
                 "gnomadPopulation",
                 "relativeSampleSize",

--- a/src/otg/dataset/study_locus.py
+++ b/src/otg/dataset/study_locus.py
@@ -1531,36 +1531,8 @@ class StudyLocusGWASCatalog(StudyLocus):
             ld_index_template,
             ld_matrix_template,
             min_r2,
-        )
-        # ld_r.write.parquet(
-        #     "gs://genetics_etl_python_playground/output/python_etl/parquet/XX.XX/locus_ancestry_ld"
-        # )
+        ).repartition(400, "chromosome", "variantId", "gnomadPopulation")
 
-        # Study-locus ld_set
-        # ld_unaggregated_set = (
-        #     self.unique_study_locus_ancestries(studies)
-        #     .join(ld_r, on=["chromosome", "variantId", "gnomadPopulation"], how="left")
-        #     .withColumn("r2", f.pow(f.col("r"), f.lit(2)))
-        #     .withColumn(
-        #         "r2Overall",
-        #         LDAnnotatorGnomad.weighted_r_overall(
-        #             f.col("chromosome"),
-        #             f.col("studyId"),
-        #             f.col("variantId"),
-        #             f.col("tagVariantId"),
-        #             f.col("relativeSampleSize"),
-        #             f.col("r2"),
-        #         ),
-        #     )
-        # )
-        # ld_unaggregated_set.write.parquet(
-        #     "gs://genetics_etl_python_playground/output/python_etl/parquet/XX.XX/catalog_study_locus_unagg",
-        #     mode="overwrite",
-        # )
-        self.unique_study_locus_ancestries(studies).write.parquet(
-            "gs://genetics_etl_python_playground/output/python_etl/parquet/XX.XX/unique_study_locus_ancestries",
-            mode="overwrite",
-        )
         ld_set = (
             self.unique_study_locus_ancestries(studies)
             .join(ld_r, on=["chromosome", "variantId", "gnomadPopulation"], how="left")

--- a/src/otg/dataset/study_locus.py
+++ b/src/otg/dataset/study_locus.py
@@ -1523,6 +1523,7 @@ class StudyLocusGWASCatalog(StudyLocus):
         Returns:
             StudyLocus: Study-locus with an annotated credible set.
         """
+        # TODO: call unique_study_locus_ancestries here so that it is not duplicated with ld_annotation_by_locus_ancestry
         # LD annotation for all unique lead variants in all populations (study independent).
         ld_r = LDAnnotatorGnomad.ld_annotation_by_locus_ancestry(
             session,

--- a/src/otg/gwas_catalog.py
+++ b/src/otg/gwas_catalog.py
@@ -21,7 +21,7 @@ class GWASCatalogStep(GWASCatalogStepConfig):
     session: Session = Session()
 
     def run(self: GWASCatalogStep) -> None:
-        """Run variant annotation step."""
+        """Run GWAS Catalog ingestion step to extract GWASCatalog Study and StudyLocus tables."""
         hl.init(sc=self.session.spark.sparkContext, log="/dev/null")
         # All inputs:
         # Variant annotation dataset

--- a/src/otg/method/ld.py
+++ b/src/otg/method/ld.py
@@ -87,16 +87,16 @@ class LDAnnotatorGnomad:
             ld_index (LDIndex): LD index precomputed
 
         Returns:
-            DataFrame: LD coordinates [i, idxs, start_idx and stop_idx]
+            DataFrame: LD coordinates [variantId, chromosome, gnomadPopulation, i, idxs, start_idx and stop_idx]
         """
         w = Window.orderBy("chromosome", "idx")
         return (
             variants_df.join(
                 ld_index.df,
-                on="variantId",
+                on=["variantId", "chromosome"],
             )  # start idx > stop idx in rare occasions due to liftover
             .filter(f.col("start_idx") < f.col("stop_idx"))
-            .groupBy("chromosome", "idx")
+            .groupBy("chromosome", "idx", "variantId", "gnomadPopulation")
             .agg(
                 f.min("start_idx").alias("start_idx"),
                 f.max("stop_idx").alias("stop_idx"),
@@ -131,7 +131,7 @@ class LDAnnotatorGnomad:
         Returns:
             Column: Estimates weighted R information
 
-        Exmples:
+        Examples:
             >>> data = [('t3', 0.25, 0.2), ('t3', 0.25, 0.2), ('t3', 0.5, 0.99)]
             >>> columns = ['tag_variant_id', 'relative_sample_size', 'r']
             >>> (

--- a/src/otg/method/ld.py
+++ b/src/otg/method/ld.py
@@ -36,9 +36,9 @@ class LDAnnotatorGnomad:
 
         Args:
             bm (BlockMatrix): LD matrix containing r values
-            idxs (List[int]): Row indexes to query (distinct and incremenetal)
+            idxs (List[int]): Row indexes to query (distinct and incremental)
             starts (List[int]): Interval start column indexes (same size as idxs)
-            stops (List[int]): Interval start column indexes (same size as idxs)
+            stops (List[int]): Interval stop column indexes (same size as idxs)
             min_r2 (float): Minimum r2 to keep
 
         Returns:
@@ -79,6 +79,8 @@ class LDAnnotatorGnomad:
         ld_index: LDIndex,
     ) -> DataFrame:
         """Idxs for variants, first variant in the region and last variant in the region in precomputed ld index.
+
+        It checks if the window defined by the start/stop indices is maintained after lifting over the variants.
 
         Args:
             variants_df (DataFrame): Lead variants from `_annotate_index_intervals` output
@@ -245,7 +247,7 @@ class LDAnnotatorGnomad:
             min_r2,
         )
 
-        return (
+        ld_expanded_variants_df = (
             entries.join(
                 f.broadcast(variants_ld_coordinates),
                 on="i",
@@ -268,6 +270,8 @@ class LDAnnotatorGnomad:
                 "variantId", "leads.chromosome", "gnomadPopulation", "tagVariantId", "r"
             )
         )
+        variants_ld_coordinates.unpersist()
+        return ld_expanded_variants_df
 
     @classmethod
     def ld_annotation_by_locus_ancestry(

--- a/src/otg/method/ld.py
+++ b/src/otg/method/ld.py
@@ -232,9 +232,9 @@ class LDAnnotatorGnomad:
         # idxs for lead, first variant in the region and last variant in the region
         variants_ld_scores = LDAnnotatorGnomad._query_block_matrix(
             ld_matrix + ld_matrix.T,
-            variants_ld_coordinates.rdd.map(lambda x: x.idxs).collect(),
-            variants_ld_coordinates.rdd.map(lambda x: x.starts).collect(),
-            variants_ld_coordinates.rdd.map(lambda x: x.stops).collect(),
+            variants_ld_coordinates.rdd.map(lambda x: x.idx).collect(),
+            variants_ld_coordinates.rdd.map(lambda x: x.start_idx).collect(),
+            variants_ld_coordinates.rdd.map(lambda x: x.stop_idx).collect(),
             min_r2,
         )
 

--- a/src/otg/method/ld.py
+++ b/src/otg/method/ld.py
@@ -340,7 +340,7 @@ class LDAnnotatorGnomad:
                         ld_matrix,
                         locus_ancestry,
                         min_r2,
-                    )
+                    ).coalesce(400)
                 )
         return reduce(DataFrame.unionByName, ld_annotated_assocs)
 

--- a/src/otg/method/ld.py
+++ b/src/otg/method/ld.py
@@ -103,6 +103,8 @@ class LDAnnotatorGnomad:
             )
             # necessary to resolve return of .entries() function
             .withColumn("i", f.row_number().over(w))
+            # the dataframe has to be ordered to query the block matrix
+            .orderBy("idx")
         )
 
     @staticmethod

--- a/src/otg/method/pics.py
+++ b/src/otg/method/pics.py
@@ -92,7 +92,7 @@ class PICS:
         return neglog_p * r2 if r2 >= 0.5 else None
 
     @staticmethod
-    def _finemap(credible_set: list, lead_neglog_p: float, k: float) -> list:
+    def _finemap(credible_set: list, lead_neglog_p: float, k: float) -> list | None:
         """Calculates the probability of a variant being causal in a study-locus context by applying the PICS method.
 
         It is intended to be applied as an UDF in `PICS.finemap`, where each row is a StudyLocus association.
@@ -107,6 +107,11 @@ class PICS:
         Returns:
             List of tagging variants with an estimation of the association signal and their posterior probability as of PICS.
         """
+        if credible_set is None:
+            return None
+        elif not credible_set:
+            return []
+
         tmp_credible_set = []
         new_credible_set = []
         # First iteration: calculation of mu, standard deviation, and the relative posterior probability
@@ -114,40 +119,40 @@ class PICS:
             tag_dict = (
                 tag_struct.asDict()
             )  # tag_struct is of type pyspark.Row, we'll represent it as a dict
-            # If PICS cannot be calculated, we'll return the original credible set
-            if tag_dict["r2Overall"] is None or lead_neglog_p is None:
+            if (
+                not tag_dict["r2Overall"]
+                or tag_dict["r2Overall"] < 0.5
+                or not lead_neglog_p
+            ):
+                # If PICS cannot be calculated, we'll return the original credible set
                 new_credible_set.append(tag_dict)
                 continue
             pics_snp_mu = PICS._pics_mu(lead_neglog_p, tag_dict["r2Overall"])
             pics_snp_std = PICS._pics_standard_deviation(
                 lead_neglog_p, tag_dict["r2Overall"], k
             )
-            posterior_probability = (
-                PICS._pics_relative_posterior_probability(
+            if pics_snp_mu and pics_snp_std:
+                posterior_probability = PICS._pics_relative_posterior_probability(
                     lead_neglog_p, pics_snp_mu, pics_snp_std
                 )
-                if pics_snp_mu and pics_snp_std
-                else None
-            )
-            tag_dict["tagPValue"] = 10**-pics_snp_mu if pics_snp_mu else None
-            tag_dict["tagStandardError"] = 10**-pics_snp_std if pics_snp_std else None
-            tag_dict["relativePosteriorProbability"] = posterior_probability
+                tag_dict["tagPValue"] = 10**-pics_snp_mu
+                tag_dict["tagStandardError"] = 10**-pics_snp_std
+                tag_dict["relativePosteriorProbability"] = posterior_probability
 
-            if posterior_probability is not None:
                 tmp_credible_set.append(tag_dict)
 
         # Second iteration: calculation of the sum of all the posteriors in each study-locus, so that we scale them between 0-1
         total_posteriors = sum(
-            tag_dict["relativePosteriorProbability"]
+            tag_dict.get("relativePosteriorProbability", 0)
             for tag_dict in tmp_credible_set
-            if tag_dict["relativePosteriorProbability"] is not None
         )
 
         # Third iteration: calculation of the final posteriorProbability
         for tag_dict in tmp_credible_set:
-            tag_dict["posteriorProbability"] = float(
-                tag_dict["relativePosteriorProbability"] / total_posteriors
-            )
+            if total_posteriors != 0:
+                tag_dict["posteriorProbability"] = float(
+                    tag_dict.get("relativePosteriorProbability", 0) / total_posteriors
+                )
             tag_dict.pop("relativePosteriorProbability")
             new_credible_set.append(tag_dict)
         return new_credible_set
@@ -181,7 +186,10 @@ class PICS:
             associations.df.withColumn("neglog_pvalue", associations.neglog_pvalue())
             .withColumn(
                 "credibleSet",
-                _finemap_udf(f.col("credibleSet"), f.col("neglog_pvalue")),
+                f.when(
+                    f.col("credibleSet").isNotNull(),
+                    _finemap_udf(f.col("credibleSet"), f.col("neglog_pvalue")),
+                ),
             )
             .drop("neglog_pvalue")
         )

--- a/src/otg/method/pics.py
+++ b/src/otg/method/pics.py
@@ -181,10 +181,7 @@ class PICS:
             associations.df.withColumn("neglog_pvalue", associations.neglog_pvalue())
             .withColumn(
                 "credibleSet",
-                f.when(
-                    f.size("credibleSet") > 0,
-                    _finemap_udf(f.col("credibleSet"), f.col("neglog_pvalue")),
-                ).otherwise(f.col("credibleSet")),
+                _finemap_udf(f.col("credibleSet"), f.col("neglog_pvalue")),
             )
             .drop("neglog_pvalue")
         )

--- a/src/otg/method/pics.py
+++ b/src/otg/method/pics.py
@@ -112,6 +112,8 @@ class PICS:
             tag_dict = (
                 tag_struct.asDict()
             )  # tag_struct is of type pyspark.Row, we'll represent it as a dict
+            if tag_dict["r2Overall"] is None:
+                continue
             pics_snp_mu = PICS._pics_mu(lead_neglog_p, tag_dict["r2Overall"])
             pics_snp_std = PICS._pics_standard_deviation(
                 lead_neglog_p, tag_dict["r2Overall"], 6.4
@@ -177,9 +179,9 @@ class PICS:
             .withColumn(
                 "credibleSet",
                 f.when(
-                    f.col("credibleSet").isNotNull(),
+                    f.size("credibleSet") > 0,
                     _finemap_udf(f.col("credibleSet"), f.col("neglog_pvalue")),
-                ),
+                ).otherwise(f.col("credibleSet")),
             )
             .drop("neglog_pvalue")
         )

--- a/src/otg/method/pics.py
+++ b/src/otg/method/pics.py
@@ -165,7 +165,7 @@ class PICS:
         """
         # Register UDF by defining the structure of the output credibleSet array of structs
         credset_schema = t.ArrayType(
-            associations.df.select("credibleSet").schema.fields[0].dataType.elementType  # type: ignore
+            [field.dataType.elementType for field in associations.schema if field.name == "credibleSet"][0]  # type: ignore
         )
         _finemap_udf = f.udf(
             lambda credible_set, neglog_p: PICS._finemap(credible_set, neglog_p),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,8 @@
 """Unit test configuration."""
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import dbldatagen as dg
 import pytest
 from pyspark.sql import DataFrame, SparkSession
@@ -17,6 +19,9 @@ from otg.dataset.summary_statistics import SummaryStatistics
 from otg.dataset.v2g import V2G
 from otg.dataset.variant_annotation import VariantAnnotation
 from otg.dataset.variant_index import VariantIndex
+
+if TYPE_CHECKING:
+    from pyspark.sql.types import StructType
 
 
 @pytest.fixture(scope="session")
@@ -198,21 +203,29 @@ def mock_study_locus_data(spark: SparkSession) -> DataFrame:
 
 
 @pytest.fixture()
-def mock_study_locus(spark: SparkSession) -> StudyLocus:
+def mock_study_locus(spark: SparkSession, study_locus_schema: StructType) -> StudyLocus:
     """Mock study_locus dataset."""
     return StudyLocus(
         _df=mock_study_locus_data(spark),
-        _schema=parse_spark_schema("study_locus.json"),
+        _schema=study_locus_schema,
     )
 
 
 @pytest.fixture()
-def mock_study_locus_gwas_catalog(spark: SparkSession) -> StudyLocus:
+def mock_study_locus_gwas_catalog(
+    spark: SparkSession, study_locus_schema: StructType
+) -> StudyLocus:
     """Mock study_locus dataset."""
     return StudyLocusGWASCatalog(
         _df=mock_study_locus_data(spark),
-        _schema=parse_spark_schema("study_locus.json"),
+        _schema=study_locus_schema,
     )
+
+
+@pytest.fixture()
+def study_locus_schema() -> StructType:
+    """Mock study_locus schema."""
+    return parse_spark_schema("study_locus.json")
 
 
 @pytest.fixture()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -180,8 +180,8 @@ def mock_study_locus_data(spark: SparkSession) -> DataFrame:
         .withColumnSpec("betaConfidenceIntervalLower", percentNulls=0.1)
         .withColumnSpec("betaConfidenceIntervalUpper", percentNulls=0.1)
         .withColumnSpec("subStudyDescription", percentNulls=0.1)
-        .withColumnSpec("pValueMantissa", percentNulls=0.1)
-        .withColumnSpec("pValueExponent", percentNulls=0.1)
+        .withColumnSpec("pValueMantissa", minValue=1, percentNulls=0.1)
+        .withColumnSpec("pValueExponent", minValue=1, percentNulls=0.1)
         .withColumnSpec(
             "qualityControls",
             expr="array(cast(rand() as string))",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -74,7 +74,6 @@ def mock_colocalisation(spark: SparkSession) -> Colocalisation:
         .withColumnSpec("coloc_log2_h4_h3", percentNulls=0.1)
         .withColumnSpec("clpp", percentNulls=0.1)
     )
-
     return Colocalisation(_df=data_spec.build(), _schema=schema)
 
 

--- a/tests/dataset/test_study_locus.py
+++ b/tests/dataset/test_study_locus.py
@@ -232,6 +232,48 @@ def test_qc_all(sample_gwas_catalog_associations: DataFrame) -> None:
                 )
             ],
         ),
+        (
+            # Null credible set
+            [
+                # Observed
+                (
+                    1,
+                    "traitA",
+                    "leadB",
+                    None,
+                ),
+            ],
+            [
+                # Expected
+                (
+                    1,
+                    "traitA",
+                    "leadB",
+                    None,
+                )
+            ],
+        ),
+        (
+            # Empty credible set
+            [
+                # Observed
+                (
+                    1,
+                    "traitA",
+                    "leadB",
+                    [],
+                ),
+            ],
+            [
+                # Expected
+                (
+                    1,
+                    "traitA",
+                    "leadB",
+                    [],
+                )
+            ],
+        ),
     ],
 )
 def test_annotate_credible_sets(

--- a/tests/method/test_ld.py
+++ b/tests/method/test_ld.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from numpy import array as nparray
+
 from otg.dataset.study_locus import StudyLocus
 from otg.method.ld import LDAnnotatorGnomad, LDclumping
 
@@ -29,3 +31,27 @@ def test_variant_coordinates_in_ldindex(
     )
     expected_cols = ["chromosome", "idx", "start_idx", "stop_idx", "i"]
     assert set(variants_w_indices_df.columns) == set(expected_cols)
+
+
+def test_variants_in_ld_in_gnomad_pop(
+    mock_variant_annotation: VariantAnnotation, mock_ld_index: LDIndex
+) -> None:
+    """Test function that annotates which variants are in LD in a particular gnomad population."""
+    r = nparray(
+        [
+            [1.0, 0.8, 0.7, 0.2],
+            [0.8, 1.0, 0.6, 0.1],
+            [0.7, 0.6, 1.0, 0.3],
+            [0.2, 0.1, 0.3, 1.0],
+        ]
+    )
+    from hail.linalg import BlockMatrix
+
+    mock_ld_matrix = BlockMatrix.from_numpy(r)
+    variants_df = mock_variant_annotation.df.select(
+        "chromosome", "position", "referenceAllele", "alternateAllele"
+    )
+    expanded_variants_df = LDAnnotatorGnomad.variants_in_ld_in_gnomad_pop(
+        variants_df, mock_ld_matrix, mock_ld_index, 0.7
+    )
+    print(expanded_variants_df.columns)

--- a/tests/method/test_ld.py
+++ b/tests/method/test_ld.py
@@ -2,10 +2,30 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from otg.dataset.study_locus import StudyLocus
-from otg.method.ld import LDclumping
+from otg.method.ld import LDAnnotatorGnomad, LDclumping
+
+if TYPE_CHECKING:
+    from otg.dataset.ld_index import LDIndex
+    from otg.dataset.variant_annotation import VariantAnnotation
 
 
 def test_clump(mock_study_locus: StudyLocus) -> None:
     """Test PICS."""
     assert isinstance(LDclumping.clump(mock_study_locus), StudyLocus)
+
+
+def test_variant_coordinates_in_ldindex(
+    mock_variant_annotation: VariantAnnotation, mock_ld_index: LDIndex
+) -> None:
+    """Test function that finds the indices of a particular set of variants in a LDIndex to query it afterwards."""
+    variants_df = mock_variant_annotation.df.select(
+        "chromosome", "position", "referenceAllele", "alternateAllele"
+    )
+    variants_w_indices_df = LDAnnotatorGnomad._variant_coordinates_in_ldindex(
+        variants_df, mock_ld_index
+    )
+    expected_cols = ["chromosome", "idx", "start_idx", "stop_idx", "i"]
+    assert set(variants_w_indices_df.columns) == set(expected_cols)

--- a/tests/method/test_ld.py
+++ b/tests/method/test_ld.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from numpy import array as nparray
+import pyspark.sql.functions as f
 
 from otg.dataset.study_locus import StudyLocus
 from otg.method.ld import LDAnnotatorGnomad, LDclumping
@@ -37,21 +37,15 @@ def test_variants_in_ld_in_gnomad_pop(
     mock_variant_annotation: VariantAnnotation, mock_ld_index: LDIndex
 ) -> None:
     """Test function that annotates which variants are in LD in a particular gnomad population."""
-    r = nparray(
-        [
-            [1.0, 0.8, 0.7, 0.2],
-            [0.8, 1.0, 0.6, 0.1],
-            [0.7, 0.6, 1.0, 0.3],
-            [0.2, 0.1, 0.3, 1.0],
-        ]
-    )
-    from hail.linalg import BlockMatrix
-
-    mock_ld_matrix = BlockMatrix.from_numpy(r)
-    variants_df = mock_variant_annotation.df.select(
-        "chromosome", "position", "referenceAllele", "alternateAllele"
+    variants_w_ld_info = mock_variant_annotation.df.select(
+        "chromosome",
+        "variantId",
+        "position",
+        f.lit("afr").alias("gnomadPopulation"),
+        f.rand().alias("r"),
+        f.rand().alias("j"),
     )
     expanded_variants_df = LDAnnotatorGnomad.variants_in_ld_in_gnomad_pop(
-        variants_df, mock_ld_matrix, mock_ld_index, 0.7
+        variants_w_ld_info, mock_ld_index
     )
     print(expanded_variants_df.columns)

--- a/tests/method/test_ld.py
+++ b/tests/method/test_ld.py
@@ -11,6 +11,7 @@ from otg.method.ld import LDAnnotatorGnomad, LDclumping
 
 if TYPE_CHECKING:
     from otg.dataset.ld_index import LDIndex
+    from otg.dataset.study_index import StudyIndexGWASCatalog
     from otg.dataset.variant_annotation import VariantAnnotation
 
 
@@ -20,11 +21,14 @@ def test_clump(mock_study_locus: StudyLocus) -> None:
 
 
 def test_variant_coordinates_in_ldindex(
-    mock_variant_annotation: VariantAnnotation, mock_ld_index: LDIndex
+    mock_study_locus: StudyLocus,
+    mock_study_index_gwas_catalog: StudyIndexGWASCatalog,
+    mock_ld_index: LDIndex,
 ) -> None:
     """Test function that finds the indices of a particular set of variants in a LDIndex to query it afterwards."""
-    variants_df = mock_variant_annotation.df.select(
-        "chromosome", "position", "referenceAllele", "alternateAllele"
+    # set of variants is defined by `unique_study_locus_ancestries``
+    variants_df = mock_study_locus.unique_study_locus_ancestries(
+        studies=mock_study_index_gwas_catalog
     )
     variants_w_indices_df = LDAnnotatorGnomad._variant_coordinates_in_ldindex(
         variants_df, mock_ld_index
@@ -48,4 +52,5 @@ def test_variants_in_ld_in_gnomad_pop(
     expanded_variants_df = LDAnnotatorGnomad.variants_in_ld_in_gnomad_pop(
         variants_w_ld_info, mock_ld_index
     )
-    print(expanded_variants_df.columns)
+    expected_cols = ["variantId", "chromosome", "gnomadPopulation", "tagVariantId", "r"]
+    assert set(expanded_variants_df.columns) == set(expected_cols)

--- a/tests/method/test_pics.py
+++ b/tests/method/test_pics.py
@@ -41,6 +41,14 @@ class TestFinemap:
         observed_df = PICS.finemap(mock_study_locus).df.limit(1)
         assert observed_df.collect()[0]["credibleSet"] == []
 
+    def test_finemap_null_credible_set(
+        self: TestFinemap, mock_study_locus: StudyLocus
+    ) -> None:
+        """Test how we apply `finemap` when `credibleSet` is null by returning a null field."""
+        mock_study_locus.df = mock_study_locus.df.filter(f.col("credibleSet").isNull())
+        observed_df = PICS.finemap(mock_study_locus).df.limit(1)
+        assert observed_df.collect()[0]["credibleSet"] is None
+
     def test_finemap_null_r2(
         self: TestFinemap, spark: SparkSession, study_locus_schema: StructType
     ) -> None:

--- a/tests/method/test_pics.py
+++ b/tests/method/test_pics.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import pyspark.sql.functions as f
+import pytest
 from pyspark.sql.types import ArrayType
 
 from otg.dataset.study_locus import StudyLocus
@@ -26,6 +27,34 @@ class TestFinemap:
             f.rand().alias("neglog_pvalue"),
             f.array().alias("credibleSet"),
         )
+        observed = (
+            df.select(self._finemap_udf_expr.alias("credibleSet"))
+            .limit(1)
+            .collect()[0]["credibleSet"]
+        )
+
+        assert observed == []
+
+    def test_finemap_null_r2(self: TestFinemap, mock_study_locus: StudyLocus) -> None:
+        """Test finemap works when `r2Overall` is null by returning the same `credibleSet` content."""
+        df = mock_study_locus.df.withColumn(
+            "credibleSet",
+            f.transform(
+                "credibleSet",
+                lambda x: x.withField("r2Overall", f.lit(None)),
+            ),
+        ).select("variantId", f.rand().alias("neglog_pvalue"), "credibleSet")
+
+        observed = (
+            df.select(self._finemap_udf_expr.alias("credibleSet"))
+            .limit(1)
+            .collect()[0]["credibleSet"]
+        )
+        print(observed)  # failing, nonetype is not iterable
+
+    @pytest.fixture(autouse=True)
+    def _setup(self: TestFinemap, mock_study_locus: StudyLocus) -> None:
+        """Prepares common fixtures for the tests."""
         credset_schema = ArrayType(
             [
                 field.dataType.elementType  # type: ignore
@@ -37,16 +66,7 @@ class TestFinemap:
             lambda credible_set, neglog_p: PICS._finemap(credible_set, neglog_p),
             credset_schema,
         )
-        observed = (
-            df.withColumn(
-                "credibleSet",
-                f.when(
-                    f.size("credibleSet") > 0,
-                    _finemap_udf(f.col("credibleSet"), f.col("neglog_pvalue")),
-                ).otherwise(f.col("credibleSet")),
-            )
-            .limit(1)
-            .collect()[0]["credibleSet"]
-        )
-
-        assert observed == []
+        self._finemap_udf_expr = f.when(
+            f.size("credibleSet") > 0,
+            _finemap_udf(f.col("credibleSet"), f.col("neglog_pvalue")),
+        ).otherwise(f.col("credibleSet"))

--- a/tests/method/test_pics.py
+++ b/tests/method/test_pics.py
@@ -2,12 +2,16 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import pyspark.sql.functions as f
-import pytest
-from pyspark.sql.types import ArrayType
 
 from otg.dataset.study_locus import StudyLocus
 from otg.method.pics import PICS
+
+if TYPE_CHECKING:
+    from pyspark.sql import SparkSession
+    from pyspark.sql.types import StructType
 
 
 def test_pics(mock_study_locus: StudyLocus) -> None:
@@ -22,51 +26,62 @@ class TestFinemap:
         self: TestFinemap, mock_study_locus: StudyLocus
     ) -> None:
         """Test finemap works when `credibleSet` is an empty array by returning an empty array."""
-        df = mock_study_locus.df.select(
-            "variantId",
-            f.rand().alias("neglog_pvalue"),
-            f.array().alias("credibleSet"),
-        )
-        observed = (
-            df.select(self._finemap_udf_expr.alias("credibleSet"))
-            .limit(1)
-            .collect()[0]["credibleSet"]
-        )
-
-        assert observed == []
-
-    def test_finemap_null_r2(self: TestFinemap, mock_study_locus: StudyLocus) -> None:
-        """Test finemap works when `r2Overall` is null by returning the same `credibleSet` content."""
-        df = mock_study_locus.df.withColumn(
+        mock_study_locus.df = mock_study_locus.df.withColumn(
             "credibleSet",
-            f.transform(
-                "credibleSet",
-                lambda x: x.withField("r2Overall", f.lit(None)),
+            # empty array following the `credibleSet` schema
+            f.when(f.col("credibleSet").isNull(), f.array()).otherwise(
+                f.col("credibleSet")
             ),
-        ).select("variantId", f.rand().alias("neglog_pvalue"), "credibleSet")
+        ).filter(f.size("credibleSet") == 0)
+        observed_df = PICS.finemap(mock_study_locus).df.limit(1)
+        assert observed_df.collect()[0]["credibleSet"] == []
 
-        observed = (
-            df.select(self._finemap_udf_expr.alias("credibleSet"))
-            .limit(1)
-            .collect()[0]["credibleSet"]
-        )
-        print(observed)  # failing, nonetype is not iterable
+    def test_finemap_null_r2(
+        self: TestFinemap, spark: SparkSession, study_locus_schema: StructType
+    ) -> None:
+        """Test finemap works when `r2Overall` is null by returning the same `credibleSet` content."""
+        mock_study_locus_null_r2_data: list = [
+            (
+                1,
+                "varA",
+                "chr1",
+                10,
+                "studyA",
+                None,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                5.0,
+                -8,
+                "0",
+                [],
+                "pics",
+                [
+                    (
+                        None,
+                        None,
+                        None,
+                        None,
+                        "tagA",
+                        None,
+                        None,
+                        None,
+                        None,
+                        None,
+                        None,
+                        None,  # null r2
+                    )
+                ],
+            )
+        ]
 
-    @pytest.fixture(autouse=True)
-    def _setup(self: TestFinemap, mock_study_locus: StudyLocus) -> None:
-        """Prepares common fixtures for the tests."""
-        credset_schema = ArrayType(
-            [
-                field.dataType.elementType  # type: ignore
-                for field in mock_study_locus.schema
-                if field.name == "credibleSet"
-            ][0]
+        mock_study_locus = StudyLocus(
+            _df=spark.createDataFrame(
+                mock_study_locus_null_r2_data, schema=study_locus_schema
+            )
         )
-        _finemap_udf = f.udf(
-            lambda credible_set, neglog_p: PICS._finemap(credible_set, neglog_p),
-            credset_schema,
-        )
-        self._finemap_udf_expr = f.when(
-            f.size("credibleSet") > 0,
-            _finemap_udf(f.col("credibleSet"), f.col("neglog_pvalue")),
-        ).otherwise(f.col("credibleSet"))
+        observed = PICS.finemap(mock_study_locus)
+        # since PICS can't be run, it returns the same content
+        assert observed.df.collect()[0] == mock_study_locus.df.collect()[0]

--- a/tests/method/test_pics.py
+++ b/tests/method/test_pics.py
@@ -22,6 +22,11 @@ def test_pics(mock_study_locus: StudyLocus) -> None:
 class TestFinemap:
     """Test PICS finemap function under different scenarios."""
 
+    def test_finemap_pipeline(self: TestFinemap, mock_study_locus: StudyLocus) -> None:
+        """Test finemap works with a mock study locus."""
+        observed = PICS.finemap(mock_study_locus)
+        assert isinstance(observed, StudyLocus)
+
     def test_finemap_empty_array(
         self: TestFinemap, mock_study_locus: StudyLocus
     ) -> None:

--- a/tests/method/test_pics.py
+++ b/tests/method/test_pics.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import pyspark.sql.functions as f
+from pyspark.sql.types import ArrayType
+
 from otg.dataset.study_locus import StudyLocus
 from otg.method.pics import PICS
 
@@ -9,3 +12,41 @@ from otg.method.pics import PICS
 def test_pics(mock_study_locus: StudyLocus) -> None:
     """Test PICS."""
     assert isinstance(PICS.finemap(mock_study_locus), StudyLocus)
+
+
+class TestFinemap:
+    """Test PICS finemap function under different scenarios."""
+
+    def test_finemap_empty_array(
+        self: TestFinemap, mock_study_locus: StudyLocus
+    ) -> None:
+        """Test finemap works when `credibleSet` is an empty array by returning an empty array."""
+        df = mock_study_locus.df.select(
+            "variantId",
+            f.rand().alias("neglog_pvalue"),
+            f.array().alias("credibleSet"),
+        )
+        credset_schema = ArrayType(
+            [
+                field.dataType.elementType  # type: ignore
+                for field in mock_study_locus.schema
+                if field.name == "credibleSet"
+            ][0]
+        )
+        _finemap_udf = f.udf(
+            lambda credible_set, neglog_p: PICS._finemap(credible_set, neglog_p),
+            credset_schema,
+        )
+        observed = (
+            df.withColumn(
+                "credibleSet",
+                f.when(
+                    f.size("credibleSet") > 0,
+                    _finemap_udf(f.col("credibleSet"), f.col("neglog_pvalue")),
+                ).otherwise(f.col("credibleSet")),
+            )
+            .limit(1)
+            .collect()[0]["credibleSet"]
+        )
+
+        assert observed == []


### PR DESCRIPTION
This PR includes:
- bugfixes and tests necessary to have a successful run
- study_index logic changes: `update_study_id` doesn't use aliases to avoid ambiguous columns references
- ld logic changes: extraction of methods in the `annotate_ld` function to facilitate testing
- pics logic changes: refactor of the main functions to account for nullable credibleSets (when a variant can't be resolved to our index) and empty credibleSets  (when the variant can't be resolved to a reference panel)

It takes 2h7min to run, consistent with @DSuveges 's previous pipeline ([job](https://console.cloud.google.com/dataproc/jobs/my_gwas_catalog-jjh5kik3boefu/monitoring?region=europe-west1&project=open-targets-genetics-dev)).

The results can be investigated here:
- Study locus `gs://genetics_etl_python_playground/output/python_etl/parquet/XX.XX/catalog_study_locus`
- Study index `gs://genetics_etl_python_playground/output/python_etl/parquet/XX.XX/catalog_study_index` 
