### PR TITLE
Fix GWASCatalog data issues

### DIFF
--- a/src/otg/assets/schemas/study_locus.json
+++ b/src/otg/assets/schemas/study_locus.json
@@ -79,12 +79,6 @@
       "type": "integer"
     },
     {
-      "metadata": {},
-      "name": "subStudyDescription",
-      "nullable": true,
-      "type": "string"
-    },
-    {
       "name": "qualityControls",
       "type": {
         "type": "array",

--- a/src/otg/assets/schemas/study_locus.json
+++ b/src/otg/assets/schemas/study_locus.json
@@ -79,6 +79,12 @@
       "type": "integer"
     },
     {
+      "metadata": {},
+      "name": "subStudyDescription",
+      "nullable": true,
+      "type": "string"
+    },
+    {
       "name": "qualityControls",
       "type": {
         "type": "array",

--- a/src/otg/common/gwas_catalog_splitter.py
+++ b/src/otg/common/gwas_catalog_splitter.py
@@ -33,7 +33,7 @@ class GWASCatalogSplitter:
         """
         return (
             f.when(
-                p_value_text.isNotNull(),
+                (p_value_text.isNotNull()) & (p_value_text != ("no_pvalue_text")),
                 f.concat(
                     association_trait,
                     f.lit(" ["),

--- a/src/otg/common/gwas_catalog_splitter.py
+++ b/src/otg/common/gwas_catalog_splitter.py
@@ -59,7 +59,7 @@ class GWASCatalogSplitter:
         Returns:
             Column: Consolidated EFO column.
         """
-        return f.coalesce(f.split(association_efo, "_"), study_efo)
+        return f.coalesce(f.split(association_efo, r"\/"), study_efo)
 
     @staticmethod
     def _resolve_study_id(study_id: Column, sub_study_description: Column) -> Column:

--- a/src/otg/dataset/study_index.py
+++ b/src/otg/dataset/study_index.py
@@ -109,9 +109,7 @@ class StudyIndexGWASCatalog(StudyIndex):
                 f.coalesce(
                     f.col("STUDY ACCESSION"), f.monotonically_increasing_id()
                 ).alias("studyId"),
-                f.coalesce(
-                    f.col("STUDY ACCESSION"), f.monotonically_increasing_id()
-                ).alias("projectId"),
+                f.lit("GCST").alias("projectId"),
                 f.lit("gwas").alias("studyType"),
                 f.col("PUBMED ID").alias("pubmedId"),
                 f.col("FIRST AUTHOR").alias("publicationFirstAuthor"),

--- a/src/otg/dataset/study_index.py
+++ b/src/otg/dataset/study_index.py
@@ -384,6 +384,8 @@ class StudyIndexGWASCatalog(StudyIndex):
     ) -> StudyIndexGWASCatalog:
         """Extract the sample size of the discovery stage of the study as annotated in the GWAS Catalog.
 
+        For some studies that measure quantitative traits, nCases and nControls can't be extracted. Therefore, we assume these are 0.
+
         Returns:
             StudyIndexGWASCatalog: object with columns `nCases`, `nControls`, and `nSamples` per `studyId` correctly extracted.
         """

--- a/src/otg/dataset/study_locus.py
+++ b/src/otg/dataset/study_locus.py
@@ -1506,7 +1506,7 @@ class StudyLocusGWASCatalog(StudyLocus):
                 study_annotation, on=["studyId", "subStudyDescription"], how="left"
             )
             .withColumn("studyId", f.coalesce("updatedStudyId", "studyId"))
-            .drop("updatedStudyId")
+            .drop("subStudyDescription", "updatedStudyId")
         )
         return self
 

--- a/src/otg/dataset/study_locus.py
+++ b/src/otg/dataset/study_locus.py
@@ -1086,17 +1086,17 @@ class StudyLocusGWASCatalog(StudyLocus):
 
         Examples:
         >>> df = spark.createDataFrame([
-        ...    ("Height", "http://www.ebi.ac.uk/efo/EFO_0000408", "European Ancestry"),
+        ...    ("Height", "http://www.ebi.ac.uk/efo/EFO_0000001,http://www.ebi.ac.uk/efo/EFO_0000002", "European Ancestry"),
         ...    ("Schizophrenia", "http://www.ebi.ac.uk/efo/MONDO_0005090", None)],
         ...    ["association_trait", "mapped_trait_uri", "pvalue_text"]
         ... )
         >>> df.withColumn('substudy_description', StudyLocusGWASCatalog._concatenate_substudy_description(df.association_trait, df.pvalue_text, df.mapped_trait_uri)).show(truncate=False)
-        +-----------------+--------------------------------------+-----------------+------------------------------------------+
-        |association_trait|mapped_trait_uri                      |pvalue_text      |substudy_description                      |
-        +-----------------+--------------------------------------+-----------------+------------------------------------------+
-        |Height           |http://www.ebi.ac.uk/efo/EFO_0000408  |European Ancestry|Height|EA|EFO_0000408                     |
-        |Schizophrenia    |http://www.ebi.ac.uk/efo/MONDO_0005090|null             |Schizophrenia|no_pvalue_text|MONDO_0005090|
-        +-----------------+--------------------------------------+-----------------+------------------------------------------+
+        +-----------------+-------------------------------------------------------------------------+-----------------+------------------------------------------+
+        |association_trait|mapped_trait_uri                                                         |pvalue_text      |substudy_description                      |
+        +-----------------+-------------------------------------------------------------------------+-----------------+------------------------------------------+
+        |Height           |http://www.ebi.ac.uk/efo/EFO_0000001,http://www.ebi.ac.uk/efo/EFO_0000002|European Ancestry|Height|EA|EFO_0000001/EFO_0000002         |
+        |Schizophrenia    |http://www.ebi.ac.uk/efo/MONDO_0005090                                   |null             |Schizophrenia|no_pvalue_text|MONDO_0005090|
+        +-----------------+-------------------------------------------------------------------------+-----------------+------------------------------------------+
         <BLANKLINE>
         """
         p_value_text = f.coalesce(
@@ -1107,11 +1107,11 @@ class StudyLocusGWASCatalog(StudyLocus):
             "|",
             association_trait,
             f.concat_ws(
-                "_",
+                "/",
                 p_value_text,
             ),
             f.concat_ws(
-                "_",
+                "/",
                 parse_efos(mapped_trait_uri),
             ),
         )

--- a/src/otg/dataset/study_locus.py
+++ b/src/otg/dataset/study_locus.py
@@ -452,11 +452,11 @@ class StudyLocusGWASCatalog(StudyLocus):
             p_value_text (Column): `pValueText` column from GWASCatalog
 
         Returns:
-            Column: mapped using GWAS Catalog mapping
+            Column: Array column after using GWAS Catalog mappings. There might be multiple mappings for a single p-value text.
 
         Example:
             >>> import pyspark.sql.types as t
-            >>> d = [("European Ancestry"), ("African ancestry"), ("Alzheimer’s Disease")]
+            >>> d = [("European Ancestry"), ("African ancestry"), ("Alzheimer’s Disease"), (""), (None)]
             >>> df = spark.createDataFrame(d, t.StringType())
             >>> df.withColumn('normalised', StudyLocusGWASCatalog._normalise_pvaluetext(f.col('value'))).show()
             +-------------------+----------+
@@ -465,6 +465,8 @@ class StudyLocusGWASCatalog(StudyLocus):
             |  European Ancestry|      [EA]|
             |   African ancestry|      [AA]|
             |Alzheimer’s Disease|      [AD]|
+            |                   |      null|
+            |               null|      null|
             +-------------------+----------+
             <BLANKLINE>
 
@@ -476,7 +478,9 @@ class StudyLocusGWASCatalog(StudyLocus):
         map_expr = f.create_map(*[f.lit(x) for x in chain(*json_dict.items())])
 
         splitted_col = f.split(f.regexp_replace(p_value_text, r"[\(\)]", ""), ",")
-        return f.transform(splitted_col, lambda x: map_expr[x])
+        return f.when(
+            p_value_text != "", f.transform(splitted_col, lambda x: map_expr[x])
+        )
 
     @staticmethod
     def _normalise_risk_allele(risk_allele: Column) -> Column:
@@ -1078,26 +1082,33 @@ class StudyLocusGWASCatalog(StudyLocus):
             mapped_trait_uri (Column): GWAS Catalog mapped trait URI column
 
         Returns:
-            A column with the substudy description in the shape EFO1_EFO2|pvaluetext1_pvaluetext2.
+            A column with the substudy description in the shape trait|pvaluetext1_pvaluetext2|EFO1_EFO2.
 
         Examples:
-            >>> d = {'association_trait': 'Height', 'pvalue_text': 'European Ancestry', 'mapped_trait_uri': 'http://www.ebi.ac.uk/efo/EFO_0000408'}
-            >>> df = spark.createDataFrame([d])
-            >>> df.withColumn('substudy_description', StudyLocusGWASCatalog._concatenate_substudy_description(df.association_trait, df.pvalue_text, df.mapped_trait_uri)).show(truncate = False)
-            +-----------------+------------------------------------+-----------------+---------------------+
-            |association_trait|mapped_trait_uri                    |pvalue_text      |substudy_description |
-            +-----------------+------------------------------------+-----------------+---------------------+
-            |Height           |http://www.ebi.ac.uk/efo/EFO_0000408|European Ancestry|Height|EA|EFO_0000408|
-            +-----------------+------------------------------------+-----------------+---------------------+
-            <BLANKLINE>
-
+        >>> df = spark.createDataFrame([
+        ...    ("Height", "http://www.ebi.ac.uk/efo/EFO_0000408", "European Ancestry"),
+        ...    ("Schizophrenia", "http://www.ebi.ac.uk/efo/MONDO_0005090", None)],
+        ...    ["association_trait", "mapped_trait_uri", "pvalue_text"]
+        ... )
+        >>> df.withColumn('substudy_description', StudyLocusGWASCatalog._concatenate_substudy_description(df.association_trait, df.pvalue_text, df.mapped_trait_uri)).show(truncate=False)
+        +-----------------+--------------------------------------+-----------------+------------------------------------------+
+        |association_trait|mapped_trait_uri                      |pvalue_text      |substudy_description                      |
+        +-----------------+--------------------------------------+-----------------+------------------------------------------+
+        |Height           |http://www.ebi.ac.uk/efo/EFO_0000408  |European Ancestry|Height|EA|EFO_0000408                     |
+        |Schizophrenia    |http://www.ebi.ac.uk/efo/MONDO_0005090|null             |Schizophrenia|no_pvalue_text|MONDO_0005090|
+        +-----------------+--------------------------------------+-----------------+------------------------------------------+
+        <BLANKLINE>
         """
+        p_value_text = f.coalesce(
+            StudyLocusGWASCatalog._normalise_pvaluetext(pvalue_text),
+            f.array(f.lit("no_pvalue_text")),
+        )
         return f.concat_ws(
             "|",
             association_trait,
             f.concat_ws(
                 "_",
-                StudyLocusGWASCatalog._normalise_pvaluetext(pvalue_text),
+                p_value_text,
             ),
             f.concat_ws(
                 "_",


### PR DESCRIPTION
This PR closes [#2959](https://github.com/opentargets/issues/issues/2959)

1. Incorrect parsing for traitFromSource was due to null values of pValue Text. The parsing is done by using the artificial `subStudyDescription` column, which consists of the concatenation of `reported trait + p value text + efo`. The lack of the second element was causing the problem. Solved in https://github.com/opentargets/genetics_etl_python/commit/34d44aabe020a2de742df69c4f6d1605fd7cb8d0 and https://github.com/opentargets/genetics_etl_python/commit/94e1a82396e9c90cc27525420eea7fdce3975a7f
2. Incorrect parsing for traitFromSourceMappedIds was due to aberrant splitting of the `subStudyDescription` column again. We were using `_` to concatenate multiple EFOs, which is the same character we use to represent the EFOs. I changes that to `/` in https://github.com/opentargets/genetics_etl_python/commit/8a44135c0c1f9ddca769ae1b7e14dc5606d28e56
3. Changed the definition of `projectId` to a literal value of `GCST` for all GWAS studies. This field was used in other places to group by studies before splitting. I changed that as well in https://github.com/opentargets/genetics_etl_python/commit/d6ffc5b047d364ae8750e12e6b6d9dc8dcb1186c and https://github.com/opentargets/genetics_etl_python/commit/10a2e6dde398a10d62cba78c017ce712133fca1a
4. No changes made for nCases and nControls, other than updating the documentation. This is not a bug, when cases and controls can't be extracted the values are set to 0. I've looked at the studies traits when this is the case, and 85% of them belong to the `measurement` therapeutic area, meaning that for cases like "platelet count" or "height", the distinction between cases and controls is pointless.

The script runs, new dataset at `gs://genetics_etl_python_playground/output/python_etl/parquet/XX.XX/catalog_study_locus` and `gs://genetics_etl_python_playground/output/python_etl/parquet/XX.XX/catalog_study_index`