### PR TITLE
Amend and reorganise troubleshooting section

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -10,7 +10,7 @@ Google Cloud configuration:
 
 Check that you have the `make` utility installed, and if not (which is unlikely), install it using your system package manager.
 
-PySpark requires Java version 8 (a.k.a. 1.8) or above to work. However, it may not work with the most recent Java versions, like Java 20 at the time of writing this section (May 2023). If you are encountering problems with initialising a Spark session, try using Java 11 or Java 8.
+Check that you have `java` installed.
 
 ## Environment configuration
 Run `make setup-dev` to install/update the necessary packages and activate the development environment. You need to do this every time you open a new shell.
@@ -47,11 +47,6 @@ Run `poetry run mkdocs serve`. This will generate the local copy of the document
 
 ## How to run the tests
 Run `poetry run pytest`.
-
-## Troubleshooting
-In some cases, Pyenv and Poetry may cause various exotic errors which are hard to diagnose and get rid of. In this case, it helps to remove them from the system completely before running the `make setup-dev` command. See instructions in [utils/remove_pyenv_poetry.md](utils/remove_pyenv_poetry.md).
-
-If you see errors related to BLAS/LAPACK libraries, see [this StackOverflow post](https://stackoverflow.com/questions/69954587/no-blas-lapack-libraries-found-when-installing-scipy) for more info.
 
 ## Contributing checklist
 When making changes, and especially when implementing a new module or feature, it's essential to ensure that all relevant sections of the code base are modified.

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,4 +24,4 @@ Ingestion and analysis of genetic and functional genomic data for the identifica
 
 This project is still in experimental phase. Please refer to the [roadmap section](./roadmap/) for more information.
 
-For information on how to configure the development environment, run the code, or contribute changes, see the [contributing section](./contributing/).
+For information on how to configure the development environment, run the code, or contribute changes, see the [contributing section](./contributing/). For known technical issues and solutions to them, see the [troubleshooting section](./troubleshooting/).

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,37 @@
+# Troubleshooting
+
+## BLAS/LAPACK
+
+If you see errors related to BLAS/LAPACK libraries, see [this StackOverflow post](https://stackoverflow.com/questions/69954587/no-blas-lapack-libraries-found-when-installing-scipy) for guidance.
+
+## Pyenv and Poetry
+
+If you see various errors thrown by Pyenv or Poetry, they can be hard to specifically diagnose and resolve. In this case, it often helps to remove those tools from the system completely. Follow these steps:
+
+1. Close your currently activated environment, if any: `exit`
+2. Uninstall Poetry: `curl -sSL https://install.python-poetry.org | python3 - --uninstall`
+3. Clear Poetry cache: `rm -rf ~/.cache/pypoetry`
+4. Clear pre-commit cache: `rm -rf ~/.cache/pre-commit`
+5. Switch to system Python shell: `pyenv shell system`
+6. Edit `~/.bashrc` to remove the lines related to Pyenv configuration
+7. Remove Pyenv configuration and cache: `rm -rf ~/.pyenv`
+
+After that, open a fresh shell session and run `make setup-dev` again.
+
+## Java
+
+Officially, PySpark requires Java version 8 (a.k.a. 1.8) or above to work. However, if you have a very recent version of Java, you may experience issues, as it may introduce breaking changes that PySpark hasn't had time to integrate. For example, as of May 2023, PySpark did not work with Java 20.
+
+If you are encountering problems with initialising a Spark session, try using Java 11.
+
+## Pre-commit
+
+If you see an error message thrown by pre-commit, which looks like this (`SyntaxError: Unexpected token '?'`), followed by a JavaScript traceback, the issue is likely with your system NodeJS version.
+
+One solution which can help in this case is to upgrade your system NodeJS version. However, this may not always be possible. For example, Ubuntu repository is several major versions behind the latest version as of July 2023.
+
+Another solution which helps is to remove Node, NodeJS, and npm from your system entirely. In this case, pre-commit will not try to rely on a system version of NodeJS and will install its own, suitable one.
+
+On Ubuntu, this can be done using `sudo apt remove node nodejs npm`, followed by `sudo apt autoremove`. But in some cases, depending on your existing installation, you may need to also manually remove some files. See [this StackOverflow answer](https://stackoverflow.com/a/41057802) for guidance.
+
+After running these commands, you are advised to open a fresh shell, and then also reinstall Pyenv and Poetry to make sure they pick up the changes (see relevant section above).

--- a/utils/remove_pyenv_poetry.md
+++ b/utils/remove_pyenv_poetry.md
@@ -1,7 +1,0 @@
-In order to completely remove Pyenv and Poetry from the system, use these steps:
-
-1. Uninstall Poetry: `curl -sSL https://install.python-poetry.org | python3 - --uninstall`
-2. Clear Poetry cache: `rm -rf ~/.cache/pypoetry`
-3. Switch to system Python shell: `pyenv shell system`
-4. Edit `~/.bashrc` to remove the lines related to Pyenv configuration
-5. Remove Pyenv configuration and cache: `rm -rf ~/.pyenv`


### PR DESCRIPTION
While committing the FinnGen sumstat ingestion changes, I encountered a very annoying bug with my pre-commit configuration. It wouldn't let me commit anything, throwing around some obscure errors with JavaScript tracebacks.

After some digging, it turned out the issue was a conflict between a system-wide NodeJS version, and a version pre-commit actually wanted. I've researched ways to fix this, and added instructions to the documentation.

I've also amended instructions for Pyenv/Poetry reinstallation to be more complete.

Finally, seeing as we now have four troubleshooting entries, I've reorganised them to occupy a separate page, `troubleshooting.md`