### PR TITLE
fix: pValueMantissa as float in summary stats

### DIFF
--- a/src/otg/assets/schemas/summary_statistics.json
+++ b/src/otg/assets/schemas/summary_statistics.json
@@ -46,7 +46,7 @@
       "metadata": {},
       "name": "pValueMantissa",
       "nullable": false,
-      "type": "double"
+      "type": "float"
     },
     {
       "metadata": {},

--- a/src/otg/common/spark_helpers.py
+++ b/src/otg/common/spark_helpers.py
@@ -222,7 +222,11 @@ def parse_pvalue(p_value: Column) -> tuple:
     )
 
     # Mantissa also needs to be rounded:
-    mantissa = f.round(pv * f.pow(f.lit(10), -exponent), 3).alias("pValueMantissa")
+    mantissa = (
+        f.round(pv * f.pow(f.lit(10), -exponent), 3)
+        .cast(t.FloatType())
+        .alias("pValueMantissa")
+    )
 
     return (mantissa, exponent)
 


### PR DESCRIPTION
As suggested by @DSuveges, we would like the `SummaryStatistics` to encode the `pValueMantissa` as `float` instead of `double` to adjust to the most appropriate resolution for this field.

This will ensure compatibility between the `SummaryStatistics` and the `StudyLocus` datasets. At the moment, both of them have a `pValueMantissa` field but are `DoubleType` and `FloatType` respectively.

@hlnicholls and @tskir you might want to pull this change to your branches once it's merged. 