### PR TITLE
feat: add `get_study_locus_id`

### DIFF
--- a/src/otg/common/utils.py
+++ b/src/otg/common/utils.py
@@ -107,3 +107,28 @@ def parse_efos(efo_uri: Column) -> Column:
     """
     colname = efo_uri._jc.toString()  # type: ignore
     return f.array_sort(f.expr(f"regexp_extract_all(`{colname}`, '([A-Z]+_[0-9]+)')"))
+
+
+def get_study_locus_id(study_id_col_name: str, variant_id_col_name: str) -> Column:
+    """Hashes a column with a variant ID and a study ID to extract a consistent studyLocusId.
+
+    Args:
+        study_id_col_name (str): column name with a study ID
+        variant_id_col_name (str): column name with a variant ID
+
+    Returns:
+        Column: column with a study locus ID
+
+    Examples:
+        >>> df = spark.createDataFrame([("GCST000001", "1_1000_A_C"), ("GCST000002", "1_1000_A_C")]).toDF("studyId", "variantId")
+        >>> df.withColumn("study_locus_id", get_study_locus_id(*["variantId", "studyId"])).show()
+        +----------+----------+--------------------+
+        |   studyId| variantId|      study_locus_id|
+        +----------+----------+--------------------+
+        |GCST000001|1_1000_A_C| 7437284926964690765|
+        |GCST000002|1_1000_A_C|-7653912547667845377|
+        +----------+----------+--------------------+
+        <BLANKLINE>
+
+    """
+    return f.xxhash64(*[study_id_col_name, variant_id_col_name]).alias("studyLocusId")


### PR DESCRIPTION
This PR contains:
- addition of `get_study_locus_id`: a function to consistently assign a studyLocusId hash

**Note: this function is currently only limited to the studyId and the variantId columns, we will expand the definition of a studyLocusId to differentiate from associations coming from the curated study vs sumstat, and other distinctive fields from the QTLs.**