### PR TITLE
refactor: some minor issues sorted out around summary statistics

### DIFF
--- a/src/otg/assets/schemas/summary_statistics.json
+++ b/src/otg/assets/schemas/summary_statistics.json
@@ -58,7 +58,7 @@
       "metadata": {},
       "name": "effectAlleleFrequencyFromSource",
       "nullable": true,
-      "type": "double"
+      "type": "float"
     },
     {
       "metadata": {},

--- a/src/otg/common/spark_helpers.py
+++ b/src/otg/common/spark_helpers.py
@@ -192,45 +192,6 @@ def calculate_neglog_pvalue(
     return -1 * (f.log10(p_value_mantissa) + p_value_exponent)
 
 
-def parse_pvalue(p_value: Column) -> tuple:
-    """Extract p-value mantissa and exponent from p-value.
-
-    Args:
-        p_value (Column): column with p-values. Will try to cast to float.
-
-    Returns:
-        tuple: contains columns pValueMantissa and pValueExponent
-
-    Examples:
-        >>> data = [(1.0),(0.5), (1e-20), (3e-3)]
-        >>> spark.createDataFrame(data, t.FloatType()).select('value',*parse_pvalue(f.col('value'))).show()
-        +-------+--------------+--------------+
-        |  value|pValueMantissa|pValueExponent|
-        +-------+--------------+--------------+
-        |    1.0|           1.0|             0|
-        |    0.5|           5.0|            -1|
-        |1.0E-20|           1.0|           -20|
-        |  0.003|           3.0|            -3|
-        +-------+--------------+--------------+
-        <BLANKLINE>
-    """
-    pv = f.when(p_value == 0, sys.float_info.min).otherwise(p_value)
-
-    # To get the right exponent we need to do some rounding:
-    exponent = (
-        f.floor(f.round(f.log10(pv), 4)).cast(t.IntegerType()).alias("pValueExponent")
-    )
-
-    # Mantissa also needs to be rounded:
-    mantissa = (
-        f.round(pv * f.pow(f.lit(10), -exponent), 3)
-        .cast(t.FloatType())
-        .alias("pValueMantissa")
-    )
-
-    return (mantissa, exponent)
-
-
 def string2camelcase(col_name: str) -> str:
     """Converting a string to camelcase.
 

--- a/src/otg/dataset/summary_statistics.py
+++ b/src/otg/dataset/summary_statistics.py
@@ -1,7 +1,6 @@
 """Summary satistics dataset."""
 from __future__ import annotations
 
-import sys
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -9,13 +8,17 @@ import pyspark.sql.functions as f
 import pyspark.sql.types as t
 
 from otg.common.schemas import parse_spark_schema
-from otg.common.spark_helpers import parse_pvalue, pvalue_to_zscore
-from otg.common.utils import split_pvalue
+from otg.common.utils import (
+    calculate_confidence_interval,
+    convert_odds_ratio_to_beta,
+    parse_pvalue,
+    split_pvalue,
+)
 from otg.dataset.dataset import Dataset
 from otg.method.window_based_clumping import WindowBasedClumping
 
 if TYPE_CHECKING:
-    from pyspark.sql import Column, DataFrame
+    from pyspark.sql import DataFrame
 
     from otg.common.session import Session
     from otg.dataset.study_locus import StudyLocus
@@ -29,85 +32,6 @@ class SummaryStatistics(Dataset):
     """
 
     _schema: t.StructType = parse_spark_schema("summary_statistics.json")
-
-    @staticmethod
-    def _convert_odds_ratio_to_beta(
-        beta: Column, odds_ratio: Column, standard_error: Column
-    ) -> tuple:
-        """Harmonizes effect and standard error to beta.
-
-        Args:
-            beta (Column): Effect in beta
-            odds_ratio (Column): Effect in odds ratio
-            standard_error (Column): Standard error of the effect
-
-        Returns:
-            tuple: beta, standard error
-
-        Examples:
-            >>> df = spark.createDataFrame([{"beta": 0.1, "oddsRatio": 1.1, "standardError": 0.1}, {"beta": None, "oddsRatio": 1.1, "standardError": 0.1}, {"beta": 0.1, "oddsRatio": None, "standardError": 0.1}, {"beta": 0.1, "oddsRatio": 1.1, "standardError": None}])
-            >>> df.select("*", *SummaryStatistics._convert_odds_ratio_to_beta(f.col("beta"), f.col("oddsRatio"), f.col("standardError"))).show()
-            +----+---------+-------------+-------------------+-------------+
-            |beta|oddsRatio|standardError|               beta|standardError|
-            +----+---------+-------------+-------------------+-------------+
-            | 0.1|      1.1|          0.1|                0.1|          0.1|
-            |null|      1.1|          0.1|0.09531017980432493|         null|
-            | 0.1|     null|          0.1|                0.1|          0.1|
-            | 0.1|      1.1|         null|                0.1|         null|
-            +----+---------+-------------+-------------------+-------------+
-            <BLANKLINE>
-
-        """
-        # We keep standard error when effect is given in beta, otherwise drop.
-        standard_error = f.when(
-            standard_error.isNotNull() & beta.isNotNull(), standard_error
-        ).alias("standardError")
-
-        # Odds ratio is converted to beta:
-        beta = (
-            f.when(beta.isNotNull(), beta)
-            .when(odds_ratio.isNotNull(), f.log(odds_ratio))
-            .alias("beta")
-        )
-
-        return (beta, standard_error)
-
-    @staticmethod
-    def _calculate_confidence_interval(
-        pvalue_mantissa: Column,
-        pvalue_exponent: Column,
-        beta: Column,
-        standard_error: Column,
-    ) -> tuple:
-        """This function calculates the confidence interval for the effect based on the p-value and the effect size.
-
-        If the standard error already available, don't re-calculate from p-value.
-
-        Args:
-            pvalue_mantissa (Column): p-value mantissa (float)
-            pvalue_exponent (Column): p-value exponent (integer)
-            beta (Column): effect size in beta (float)
-            standard_error (Column): standard error.
-
-        Returns:
-            tuple: betaConfidenceIntervalLower (float), betaConfidenceIntervalUpper (float)
-        """
-        # Calculate p-value from mantissa and exponent:
-        pvalue = pvalue_mantissa * f.pow(10, pvalue_exponent)
-
-        # Fix p-value underflow:
-        pvalue = f.when(pvalue == 0, sys.float_info.min).otherwise(pvalue)
-
-        # Compute missing standard error:
-        standard_error = f.when(
-            standard_error.isNull(), f.abs(beta) / f.abs(pvalue_to_zscore(pvalue))
-        ).otherwise(standard_error)
-
-        # Calculate upper and lower confidence interval:
-        ci_lower = (beta - standard_error).alias("betaConfidenceIntervalLower")
-        ci_upper = (beta + standard_error).alias("betaConfidenceIntervalUpper")
-
-        return (ci_lower, ci_upper)
 
     @classmethod
     def from_parquet(
@@ -131,25 +55,28 @@ class SummaryStatistics(Dataset):
         sumstats_df: DataFrame,
         study_id: str,
     ) -> SummaryStatistics:
-        """Create summary statistics object from summary statistics harmonized by the GWAS Catalog.
+        """Create summary statistics object from summary statistics flatfile, harmonized by the GWAS Catalog.
 
         Args:
-            sumstats_df (DataFrame): Harmonized dataset read as dataframe from GWAS Catalog.
-            study_id (str): GWAS Catalog Study accession.
+            sumstats_df (DataFrame): Harmonized dataset read as a spark dataframe from GWAS Catalog.
+            study_id (str): GWAS Catalog study accession.
 
         Returns:
             SummaryStatistics
         """
         # The effect allele frequency is an optional column, we have to test if it is there:
         allele_frequency_expression = (
-            f.col("hm_effect_allele_frequency").cast(t.DoubleType())
+            f.col("hm_effect_allele_frequency").cast(t.FloatType())
             if "hm_effect_allele_frequency" in sumstats_df.columns
             else f.lit(None)
         )
 
         # Processing columns of interest:
         processed_sumstats_df = (
-            sumstats_df.select(
+            sumstats_df
+            # Dropping rows which doesn't have proper position:
+            .filter(f.col("hm_pos").cast(t.IntegerType()).isNotNull())
+            .select(
                 # Adding study identifier:
                 f.lit(study_id).cast(t.StringType()).alias("studyId"),
                 # Adding variant identifier:
@@ -157,9 +84,9 @@ class SummaryStatistics(Dataset):
                 f.col("hm_chrom").alias("chromosome"),
                 f.col("hm_pos").cast(t.IntegerType()).alias("position"),
                 # Parsing p-value mantissa and exponent:
-                *parse_pvalue(f.col("p_value").cast(t.FloatType())),
+                *parse_pvalue(f.col("p_value")),
                 # Converting/calculating effect and confidence interval:
-                *cls._convert_odds_ratio_to_beta(
+                *convert_odds_ratio_to_beta(
                     f.col("hm_beta").cast(t.DoubleType()),
                     f.col("hm_odds_ratio").cast(t.DoubleType()),
                     f.col("standard_error").cast(t.DoubleType()),
@@ -175,7 +102,9 @@ class SummaryStatistics(Dataset):
             _df=processed_sumstats_df,
         )
 
-    def calculate_confidence_interval(self: SummaryStatistics) -> SummaryStatistics:
+    def calculate_confidence_interval_for_summary_statistics(
+        self: SummaryStatistics,
+    ) -> SummaryStatistics:
         """A Function to add upper and lower confidence interval to a summary statistics dataset.
 
         Returns:
@@ -195,7 +124,7 @@ class SummaryStatistics(Dataset):
             _df=(
                 self._df.select(
                     "*",
-                    *self._calculate_confidence_interval(
+                    *calculate_confidence_interval(
                         f.col("pValueMantissa"),
                         f.col("pValueExponent"),
                         f.col("beta"),


### PR DESCRIPTION
I have moved some of the methods initially shipped with summary statistics, but thinking about them more closely, they can be re-used in the other processes eg. when ingesting curated associations.

Now GWAS Catalog harmonized sumstats can be ingested as follows:

```python
study_id = 'GCST90016941'
file = f'{sumstats_path}/33462485-GCST90016941-EFO_0007874.h.tsv.gz'
pvalue_threshold = 5e-6
distance_threshold = 2.5e5

df = spark.read.csv(file, sep='\t', header=True)

leads = (
    SummaryStatistics
    .from_gwas_harmonized_summary_stats(df, study_id)
    .pvalue_filter(pvalue_threshold)
    .window_based_clumping(distance_threshold)
)

print(type(leads))
leads.df.printSchema()
leads.df.show()
```