### PR TITLE
Fixes to the `annotate_ld` function

### DIFF
--- a/src/otg/dataset/study_locus.py
+++ b/src/otg/dataset/study_locus.py
@@ -1532,7 +1532,7 @@ class StudyLocusGWASCatalog(StudyLocus):
             ld_populations (list[str]): List of populations to annotate
             ld_index_template (str): Template path of the LD matrix index containing `{POP}` where the population is expected
             ld_matrix_template (str): Template path of the LD matrix containing `{POP}` where the population is expected
-            min_r2 (float): Minimum r2 to include in the LD set
+            min_r2 (float): Minimum r2 to include in the LD set after weighting per population (r2Overall)
 
         Returns:
             StudyLocus: Study-locus with an annotated credible set.
@@ -1546,7 +1546,7 @@ class StudyLocusGWASCatalog(StudyLocus):
             ld_populations,
             ld_index_template,
             ld_matrix_template,
-            min_r2,
+            min_r2=0.2,
         ).coalesce(400)
 
         ld_set = (
@@ -1564,6 +1564,7 @@ class StudyLocusGWASCatalog(StudyLocus):
                     f.col("r2"),
                 ),
             )
+            .filter(f.col("r2Overall") >= min_r2)
             .groupBy("chromosome", "studyId", "variantId")
             .agg(
                 f.collect_set(

--- a/src/otg/method/ld.py
+++ b/src/otg/method/ld.py
@@ -317,7 +317,7 @@ class LDAnnotatorGnomad:
         locus_ancestry = (
             associations.unique_study_locus_ancestries(studies)
             # Ignoring study information / relativeSampleSize to get unique lead-ancestry pairs
-            .drop("studyId", "relativeSampleSize")
+            .select("variantId", "chromosome", "gnomadPopulation")
             .distinct()
             .persist()
         )

--- a/src/otg/method/ld.py
+++ b/src/otg/method/ld.py
@@ -323,9 +323,9 @@ class LDAnnotatorGnomad:
         )
 
         # All gnomad populations captured in associations:
-        assoc_populations = locus_ancestry.rdd.map(
-            lambda x: x.gnomadPopulation
-        ).collect()
+        assoc_populations = (
+            locus_ancestry.rdd.map(lambda x: x.gnomadPopulation).distinct().collect()
+        )
 
         # Retrieve LD information from gnomAD
         ld_annotated_assocs = []

--- a/src/otg/method/ld.py
+++ b/src/otg/method/ld.py
@@ -88,7 +88,7 @@ class LDAnnotatorGnomad:
         Returns:
             DataFrame: LD coordinates [variantId, chromosome, gnomadPopulation, i, idxs, start_idx and stop_idx]
         """
-        w = Window.orderBy("chromosome", "idx")
+        w = Window.orderBy("idx")
         return (
             variants_df.join(
                 ld_index.df,

--- a/src/otg/method/ld.py
+++ b/src/otg/method/ld.py
@@ -104,7 +104,7 @@ class LDAnnotatorGnomad:
             )
             .distinct()
             # necessary to resolve return of .entries() function
-            .withColumn("i", f.row_number().over(w))
+            .withColumn("i", f.row_number().over(w) - 1)
             # the dataframe has to be ordered to query the block matrix
             .orderBy("idx")
         )


### PR DESCRIPTION
This PR contains:
- fixes to close https://github.com/opentargets/issues/issues/3019
- changes to adjust the r2 threshold for the LD matrix to annotate all variants with a correlation of .2. The threshold of .5 is maintained once the r2Overall is calculated. __Note: allowing for a more flexible threshold didnt impact the step runtime.__

**As noted in https://github.com/opentargets/genetics_etl_python/pull/105, the function to annotate the LD set will change with the new LDIndex. These changes were mostly fixes on how to operate with the LDIndex. When the new dataset is in place, I expect that most of this logic will be affected (for the better).** 