### PR TITLE
New LD annotator for GWASCatalog curated studies

### DIFF
--- a/config/step/my_gwas_catalog.yaml
+++ b/config/step/my_gwas_catalog.yaml
@@ -7,7 +7,6 @@ catalog_ancestry_file: ${datasets.catalog_ancestries}
 catalog_associations_file: ${datasets.catalog_associations}
 catalog_sumstats_lut: ${datasets.catalog_sumstats_lut}
 variant_annotation_path: ${datasets.variant_annotation}
+ld_index_path: ${datasets.ld_index_path}
 catalog_studies_out: ${datasets.catalog_study_index}
 catalog_associations_out: ${datasets.catalog_study_locus}
-ld_matrix_template: ${datasets.ld_matrix_template}
-ld_index_template: ${datasets.ld_index_template} # TODO: remove

--- a/config/step/my_gwas_catalog.yaml
+++ b/config/step/my_gwas_catalog.yaml
@@ -7,6 +7,6 @@ catalog_ancestry_file: ${datasets.catalog_ancestries}
 catalog_associations_file: ${datasets.catalog_associations}
 catalog_sumstats_lut: ${datasets.catalog_sumstats_lut}
 variant_annotation_path: ${datasets.variant_annotation}
-ld_index_path: ${datasets.ld_index_path}
+ld_index_path: ${datasets.ld_index}
 catalog_studies_out: ${datasets.catalog_study_index}
 catalog_associations_out: ${datasets.catalog_study_locus}

--- a/config/step/my_gwas_catalog.yaml
+++ b/config/step/my_gwas_catalog.yaml
@@ -10,4 +10,4 @@ variant_annotation_path: ${datasets.variant_annotation}
 catalog_studies_out: ${datasets.catalog_study_index}
 catalog_associations_out: ${datasets.catalog_study_locus}
 ld_matrix_template: ${datasets.ld_matrix_template}
-ld_index_template: ${datasets.ld_index_template}
+ld_index_template: ${datasets.ld_index_template} # TODO: remove

--- a/src/otg/assets/schemas/ld_index.json
+++ b/src/otg/assets/schemas/ld_index.json
@@ -8,6 +8,12 @@
     },
     {
       "metadata": {},
+      "name": "chromosome",
+      "nullable": false,
+      "type": "string"
+    },
+    {
+      "metadata": {},
       "name": "ldSet",
       "nullable": false,
       "type": {

--- a/src/otg/assets/schemas/study_locus.json
+++ b/src/otg/assets/schemas/study_locus.json
@@ -114,6 +114,32 @@
     },
     {
       "metadata": {},
+      "name": "ldSet",
+      "nullable": true,
+      "type": {
+        "containsNull": true,
+        "elementType": {
+          "fields": [
+            {
+              "metadata": {},
+              "name": "tagVariantId",
+              "nullable": true,
+              "type": "string"
+            },
+            {
+              "metadata": {},
+              "name": "r2Overall",
+              "nullable": true,
+              "type": "double"
+            }
+          ],
+          "type": "struct"
+        },
+        "type": "array"
+      }
+    },
+    {
+      "metadata": {},
       "name": "credibleSet",
       "nullable": true,
       "type": {

--- a/src/otg/config.py
+++ b/src/otg/config.py
@@ -209,21 +209,8 @@ class GWASCatalogStepConfig:
     catalog_sumstats_lut: str = MISSING
     catalog_associations_file: str = MISSING
     variant_annotation_path: str = MISSING
+    ld_index_path: str = MISSING
     min_r2: float = 0.5
-    ld_matrix_template: str = MISSING
-    ld_index_template: str = MISSING  # TODO: remove
-    ld_populations: List[str] = field(
-        default_factory=lambda: [
-            "afr",  # African-American
-            "amr",  # American Admixed/Latino
-            "asj",  # Ashkenazi Jewish
-            "eas",  # East Asian
-            "fin",  # Finnish
-            "nfe",  # Non-Finnish European
-            "nwe",  # Northwestern European
-            "seu",  # Southeastern European
-        ]
-    )
     catalog_studies_out: str = MISSING
     catalog_associations_out: str = MISSING
 

--- a/src/otg/dataset/ld_index.py
+++ b/src/otg/dataset/ld_index.py
@@ -240,3 +240,17 @@ class LDIndex(Dataset):
         return cls(
             _df=cls._aggregate_ld_index_across_populations(ld_index_unaggregated),
         )
+
+    @classmethod
+    def from_parquet(cls: type[LDIndex], session: Session, path: str) -> LDIndex:
+        """Initialise LDIndex from parquet file.
+
+        Args:
+            session (Session): ETL session
+            path (str): Path to parquet file
+
+        Returns:
+            LDIndex: VariantAnnotation dataset
+        """
+        df = session.read_parquet(path=path, schema=cls._schema)
+        return cls(_df=df, _schema=cls._schema)

--- a/src/otg/dataset/study_index.py
+++ b/src/otg/dataset/study_index.py
@@ -178,13 +178,13 @@ class StudyIndexGWASCatalog(StudyIndex):
             )
             # mapped to gnomAD superpopulation and exploded
             .withColumn(
-                "gnomadPopulation",
+                "population",
                 f.explode(
                     StudyIndexGWASCatalog._gwas_ancestry_to_gnomad(f.col("ancestries"))
                 ),
             )
             # Group by studies and aggregate for major population:
-            .groupBy("studyId", "gnomadPopulation")
+            .groupBy("studyId", "population")
             .agg(f.sum(f.col("adjustedSampleSize")).alias("sampleSize"))
             # Calculate proportions for each study
             .withColumn(
@@ -193,7 +193,7 @@ class StudyIndexGWASCatalog(StudyIndex):
             )
             .withColumn(
                 "populationStructure",
-                f.struct("gnomadPopulation", "relativeSampleSize"),
+                f.struct("population", "relativeSampleSize"),
             )
             .groupBy("studyId")
             .agg(f.collect_set("populationStructure").alias("populationsStructure"))

--- a/src/otg/dataset/study_locus.py
+++ b/src/otg/dataset/study_locus.py
@@ -286,40 +286,6 @@ class StudyLocus(Dataset):
             .distinct()
         )
 
-    def unique_study_locus_ancestries(
-        self: StudyLocus, studies: StudyIndexGWASCatalog
-    ) -> DataFrame:
-        """All unique lead variant and ancestries contained in the `StudyLocus`.
-
-        Args:
-            studies (StudyIndexGWASCatalog): Metadata about studies in the `StudyLocus`.
-
-        Returns:
-            DataFrame: unique ["variantId", "studyId", "gnomadPopulation", "chromosome", "relativeSampleSize"]
-
-        Note:
-            This method is only available for GWAS Catalog studies.
-        """
-        return (
-            self.df.join(
-                studies.get_gnomad_population_structure(), on="studyId", how="left"
-            )
-            .filter(f.col("position").isNotNull())
-            .withColumn(
-                "studyPopulations",
-                f.collect_set("gnomadPopulation").over(Window.partitionBy("studyId")),
-            )
-            .select(
-                "variantId",
-                "chromosome",
-                "studyId",
-                "gnomadPopulation",
-                "studyPopulations",
-                "relativeSampleSize",
-            )
-            .distinct()
-        )
-
     def neglog_pvalue(self: StudyLocus) -> Column:
         """Returns the negative log p-value.
 

--- a/src/otg/dataset/study_locus.py
+++ b/src/otg/dataset/study_locus.py
@@ -1554,15 +1554,17 @@ class StudyLocusGWASCatalog(StudyLocus):
         )
         return self
 
-    def _qc_unresolved_ld(self: StudyLocusGWASCatalog) -> StudyLocusGWASCatalog:
+    def _qc_unresolved_ld(
+        self: StudyLocus | StudyLocusGWASCatalog,
+    ) -> StudyLocus | StudyLocusGWASCatalog:
         """Flag associations with variants that are not found in the LD reference.
 
         Returns:
-            StudyLocusGWASCatalog: Updated study locus.
+            StudyLocusGWASCatalog | StudyLocus: Updated study locus.
         """
-        self._df.withColumn(
+        self.df = self.df.withColumn(
             "qualityControls",
-            StudyLocus._update_quality_flag(
+            self._update_quality_flag(
                 f.col("qualityControls"),
                 f.col("ldSet").isNull(),
                 StudyLocusQualityCheck.UNRESOLVED_LD,

--- a/src/otg/dataset/study_locus.py
+++ b/src/otg/dataset/study_locus.py
@@ -273,7 +273,7 @@ class StudyLocus(Dataset):
             self.df.select(
                 f.col("variantId"),
                 f.col("chromosome"),
-                f.explode("credibleSet.tagVariantId").alias("tagVariantId"),
+                f.explode("ldSet.tagVariantId").alias("tagVariantId"),
             )
             .repartition("chromosome")
             .persist()
@@ -394,14 +394,12 @@ class StudyLocus(Dataset):
                     self.df.variantId,
                     self.df.pValueExponent,
                     self.df.pValueMantissa,
-                    self.df.credibleSet,
+                    self.df.ldSet,
                 ),
             )
             .withColumn(
-                "credibleSet",
-                f.when(f.col("is_lead_linked"), f.array()).otherwise(
-                    f.col("credibleSet")
-                ),
+                "ldSet",
+                f.when(f.col("is_lead_linked"), f.array()).otherwise(f.col("ldSet")),
             )
             .withColumn(
                 "qualityControls",

--- a/src/otg/method/ld.py
+++ b/src/otg/method/ld.py
@@ -1,347 +1,115 @@
 """Performing linkage disequilibrium (LD) operations."""
 from __future__ import annotations
 
-from functools import reduce
 from typing import TYPE_CHECKING
 
-from pyspark.sql import DataFrame, Window
 from pyspark.sql import functions as f
 
-from otg.dataset.ld_index import LDIndex
-
 if TYPE_CHECKING:
-    from otg.common.session import Session
-    from pyspark.sql import Column
-    from otg.dataset.study_index import StudyIndexGWASCatalog
-    from otg.dataset.study_locus import (
-        StudyLocusGWASCatalog,
-    )
+    from pyspark.sql import Column, DataFrame
 
-from hail.linalg import BlockMatrix
+    from otg.dataset.ld_index import LDIndex
 
 
-class LDAnnotatorGnomad:
+class LDAnnotator:
     """Class to annotate linkage disequilibrium (LD) operations from GnomAD."""
 
     @staticmethod
-    def _query_block_matrix(
-        bm: BlockMatrix,
-        idxs: list[int],
-        starts: list[int],
-        stops: list[int],
-        min_r2: float,
-    ) -> DataFrame:
-        """Query block matrix for idxs rows sparsified by start/stop columns.
-
-        Args:
-            bm (BlockMatrix): LD matrix containing r values
-            idxs (List[int]): Row indexes to query (distinct and incremental)
-            starts (List[int]): Interval start column indexes (same size as idxs)
-            stops (List[int]): Interval stop column indexes (same size as idxs)
-            min_r2 (float): Minimum r2 to keep
-
-        Returns:
-            DataFrame: i,j,r where i and j are the row and column indexes and r is the LD
-
-        Examples:
-            >>> import numpy as np
-            >>> r = np.array([[1, 0.8, 0.7, 0.2],
-            ...               [0.8, 1, 0.6, 0.1],
-            ...               [0.7, 0.6, 1, 0.3],
-            ...               [0.2, 0.1, 0.3, 1]])
-            >>> bm_r = BlockMatrix.from_numpy(r) # doctest: +SKIP
-            >>> LDAnnotatorGnomad._query_block_matrix(bm_r, [1, 2], [0, 1], [3, 4], 0.5).show() # doctest: +SKIP
-            +---+---+---+
-            |  i|  j|  r|
-            +---+---+---+
-            |  0|  0|0.8|
-            |  0|  1|1.0|
-            |  1|  2|1.0|
-            +---+---+---+
-            <BLANKLINE>
-        """
-        bm_sparsified = bm.filter_rows(idxs).sparsify_row_intervals(
-            starts, stops, blocks_only=True
-        )
-        entries = bm_sparsified.entries(keyed=False)
-
-        return (
-            entries.rename({"entry": "r"})
-            .to_spark()
-            .filter(f.col("r") ** 2 >= min_r2)
-            .withColumn("r", f.when(f.col("r") >= 1, f.lit(1)).otherwise(f.col("r")))
-        )
-
-    @staticmethod
-    def _variant_coordinates_in_ldindex(
-        variants_df: DataFrame,
-        ld_index: LDIndex,
-    ) -> DataFrame:
-        """Idxs for variants, first variant in the region and last variant in the region in precomputed ld index.
-
-        It checks if the window defined by the start/stop indices is maintained after lifting over the variants.
-
-        Args:
-            variants_df (DataFrame): Lead variants from `_annotate_index_intervals` output
-            ld_index (LDIndex): LD index precomputed
-
-        Returns:
-            DataFrame: LD coordinates [variantId, chromosome, gnomadPopulation, i, idxs, start_idx and stop_idx]
-        """
-        w = Window.orderBy("chromosome", "idx")
-        return (
-            variants_df.join(
-                ld_index.df,
-                on=["variantId", "chromosome"],
-            )
-            .select(
-                "variantId",
-                "chromosome",
-                "gnomadPopulation",
-                "idx",
-                "start_idx",
-                "stop_idx",
-            )
-            .distinct()
-            # necessary to resolve return of .entries() function
-            .withColumn("i", f.row_number().over(w))
-            # the dataframe has to be ordered to query the block matrix
-            .orderBy("idx")
-        )
-
-    @staticmethod
-    def weighted_r_overall(
-        chromosome: Column,
-        study_id: Column,
-        variant_id: Column,
-        tag_variant_id: Column,
-        relative_sample_size: Column,
-        r: Column,
-    ) -> Column:
-        """Aggregation of weighted R information using ancestry proportions.
-
-        The method implements a simple average weighted by the relative population sizes.
-
-        Args:
-            chromosome (Column): Chromosome
-            study_id (Column): Study identifier
-            variant_id (Column): Variant identifier
-            tag_variant_id (Column): Tag variant identifier
-            relative_sample_size (Column): Relative sample size
-            r (Column): Correlation
-
-        Returns:
-            Column: Estimates weighted R information
-
-        Examples:
-            >>> data = [('t3', 0.25, 0.2), ('t3', 0.25, 0.2), ('t3', 0.5, 0.99)]
-            >>> columns = ['tag_variant_id', 'relative_sample_size', 'r']
-            >>> (
-            ...    spark.createDataFrame(data, columns)
-            ...     .withColumn('chr', f.lit('chr1'))
-            ...     .withColumn('study_id', f.lit('s1'))
-            ...     .withColumn('variant_id', f.lit('v1'))
-            ...     .withColumn(
-            ...         'r_overall',
-            ...         LDAnnotatorGnomad.weighted_r_overall(
-            ...             f.col('chr'),
-            ...             f.col('study_id'),
-            ...             f.col('variant_id'),
-            ...             f.col('tag_variant_id'),
-            ...             f.col('relative_sample_size'),
-            ...             f.col('r')
-            ...         )
-            ...     )
-            ...     .show()
-            ... )
-            +--------------+--------------------+----+----+--------+----------+---------+
-            |tag_variant_id|relative_sample_size|   r| chr|study_id|variant_id|r_overall|
-            +--------------+--------------------+----+----+--------+----------+---------+
-            |            t3|                0.25| 0.2|chr1|      s1|        v1|    0.595|
-            |            t3|                0.25| 0.2|chr1|      s1|        v1|    0.595|
-            |            t3|                 0.5|0.99|chr1|      s1|        v1|    0.595|
-            +--------------+--------------------+----+----+--------+----------+---------+
-            <BLANKLINE>
-        """
-        pseudo_r = f.when(r >= 1, 0.9999995).otherwise(r)
-        return f.round(
-            f.sum(pseudo_r * relative_sample_size).over(
-                Window.partitionBy(chromosome, study_id, variant_id, tag_variant_id)
+    def _calculate_weighted_r_overall(ld_set: Column) -> Column:
+        """Aggregation of weighted R information using ancestry proportions."""
+        return f.transform(
+            ld_set,
+            lambda x: f.struct(
+                x["tagVariantId"].alias("tagVariantId"),
+                # r2Overall is the accumulated sum of each r2 relative to the population size
+                f.aggregate(
+                    x["rValues"],
+                    f.lit(0.0),
+                    lambda acc, y: acc
+                    + f.coalesce(
+                        f.pow(y["r"], 2) * y["relativeSampleSize"], f.lit(0.0)
+                    ),  # we use coalesce to avoid problems when r/relativeSampleSize is null
+                ).alias("r2Overall"),
             ),
-            6,
         )
 
     @staticmethod
-    def _flag_partial_mapped(
-        study_id: Column, variant_id: Column, tag_variant_id: Column
-    ) -> Column:
-        """Generate flag for lead/tag pairs.
-
-        Some lead variants can be resolved in one population but not in other. Those rows interfere with PICS calculation, so they needs to be dropped.
+    def _add_population_size(ld_set: Column, study_populations: Column) -> Column:
+        """Add population size to each rValues entry in the ldSet.
 
         Args:
-            study_id (Column): Study identifier column
-            variant_id (Column): Identifier of the lead variant
-            tag_variant_id (Column): Identifier of the tag variant
+            ld_set (Column): LD set
+            study_populations (Column): Study populations
 
         Returns:
-            Column: Boolean
-
-        Examples:
-            >>> data = [
-            ...     ('study_1', 'lead_1', 'tag_1'),  # <- keep row as tag available.
-            ...     ('study_1', 'lead_1', 'tag_2'),  # <- keep row as tag available.
-            ...     ('study_1', 'lead_2', 'tag_3'),  # <- keep row as tag available
-            ...     ('study_1', 'lead_2', None),  # <- drop row as lead 2 is resolved.
-            ...     ('study_1', 'lead_3', None)   # <- keep row as lead 3 is not resolved.
-            ... ]
-            >>> (
-            ...     spark.createDataFrame(data, ['studyId', 'variantId', 'tagVariantId'])
-            ...     .withColumn("flag_to_keep_tag", LDAnnotatorGnomad._flag_partial_mapped(f.col('studyId'), f.col('variantId'), f.col('tagVariantId')))
-            ...     .show()
-            ... )
-            +-------+---------+------------+----------------+
-            |studyId|variantId|tagVariantId|flag_to_keep_tag|
-            +-------+---------+------------+----------------+
-            |study_1|   lead_1|       tag_1|            true|
-            |study_1|   lead_1|       tag_2|            true|
-            |study_1|   lead_2|       tag_3|            true|
-            |study_1|   lead_2|        null|           false|
-            |study_1|   lead_3|        null|            true|
-            +-------+---------+------------+----------------+
-            <BLANKLINE>
+            Column: LD set with added 'relativeSampleSize' field
         """
-        return tag_variant_id.isNotNull() | ~f.array_contains(
-            f.collect_set(tag_variant_id.isNotNull()).over(
-                Window.partitionBy(study_id, variant_id)
+        # Create a population to relativeSampleSize map from the struct
+        populations_map = f.map_from_arrays(
+            study_populations["population"],
+            study_populations["relativeSampleSize"],
+        )
+        return f.transform(
+            ld_set,
+            lambda x: f.struct(
+                x["tagVariantId"].alias("tagVariantId"),
+                f.transform(
+                    x["rValues"],
+                    lambda y: f.struct(
+                        y["population"].alias("population"),
+                        y["r"].alias("r"),
+                        populations_map[y["population"]].alias("relativeSampleSize"),
+                    ),
+                ).alias("rValues"),
             ),
-            True,
         )
 
-    @staticmethod
-    def get_ld_annotated_assocs_for_population(
-        population: str,
-        ld_index: LDIndex,
-        ld_matrix: BlockMatrix,
-        locus_ancestry: DataFrame,
-        min_r2: float,
+    def annotate_variants_with_ld(
+        self: LDAnnotator, variants_df: DataFrame, ld_index: LDIndex
     ) -> DataFrame:
-        """This function annotates association data with LD information."""
-        # map variants to precomputed LD indexes from gnomAD
-        variants_in_pop = locus_ancestry.filter(f.col("gnomadPopulation") == population)
-        variants_ld_coordinates = LDAnnotatorGnomad._variant_coordinates_in_ldindex(
-            variants_in_pop, ld_index
-        ).persist()
-
-        # idxs for lead, first variant in the region and last variant in the region
-        variants_ld_scores = LDAnnotatorGnomad._query_block_matrix(
-            ld_matrix + ld_matrix.T,
-            variants_ld_coordinates.rdd.map(lambda x: x.idx).collect(),
-            variants_ld_coordinates.rdd.map(lambda x: x.start_idx).collect(),
-            variants_ld_coordinates.rdd.map(lambda x: x.stop_idx).collect(),
-            min_r2,
-        )
-
-        # aggregate LD info
-        variants_ld_info = variants_ld_scores.join(
-            f.broadcast(variants_ld_coordinates),
-            on="i",
-            how="inner",
-        ).select("variantId", "chromosome", "gnomadPopulation", "j", "r")
-
-        variants_ld_coordinates.unpersist()
-        return LDAnnotatorGnomad.variants_in_ld_in_gnomad_pop(
-            variants_ld_info=variants_ld_info,
-            ld_index=ld_index,
-        )
-
-    @classmethod
-    def variants_in_ld_in_gnomad_pop(
-        cls: type[LDAnnotatorGnomad],
-        variants_ld_info: DataFrame,
-        ld_index: LDIndex,
-    ) -> DataFrame:
-        """Return LD annotation for variants in specific gnomad population.
+        """Annotate linkage disequilibrium (LD) information to a set of variants.
 
         Args:
-            variants_ld_info (DataFrame): variant and their LD scores (r) and coordinates from the LD matrix of a population
-            ld_index (LDIndex): LD index precomputed
+            variants_df (DataFrame): Input DataFrame with a `variantId` column containing variant IDs (hg38)
+            ld_index (LDIndex): LD index
 
         Returns:
-            DataFrame: LD information in the columns ["variantId", "chromosome", "gnomadPopulation", "tagVariantId", "r"]
+            DataFrame: DataFrame with LD annotations
+        """
+        return variants_df.join(ld_index.df, on=["variantId", "chromosome"], how="left")
+
+    def annotate_associations_with_ld(
+        self: LDAnnotator,
+        associations_df: DataFrame,
+        ld_index: LDIndex,
+    ) -> DataFrame:
+        """Annotate linkage disequilibrium (LD) information to a set of associations.
+
+        We first join the associations dataframe with the LD index. Then, we add the population size of the study to each rValues entry in the ldSet to calculate the relative r between lead/tag for that study.
+        Finally, we aggregate the weighted R information using ancestry proportions.
+
+        Args:
+            associations_df (DataFrame): Study locus DataFrame with a `populationsStructure` column containing population structure information
+            ld_index (LDIndex): Dataset with LD information for every variant present in gnomAD LD matrix
+
+        Returns:
+            DataFrame: Following the same schema as the input DataFrame, but with LD annotations (`ldSet` column)
         """
         return (
-            variants_ld_info.alias("left")
-            .join(
-                ld_index.df.select(
-                    f.col("chromosome"),
-                    f.col("variantId").alias("tagVariantId"),
-                    f.col("idx").alias("tag_idx"),
-                ).alias("tags"),
-                on=[
-                    f.col("left.chromosome") == f.col("tags.chromosome"),
-                    f.col("left.j") == f.col("tags.tag_idx"),
-                ],
+            # Bring LD information
+            associations_df.join(
+                ld_index.df, on=["variantId", "chromosome"], how="left"
             )
-            .select(
-                "variantId", "left.chromosome", "gnomadPopulation", "tagVariantId", "r"
+            # Add population size to each rValues entry in the ldSet
+            .withColumn(
+                "ldSet",
+                self._add_population_size(
+                    f.col("ldSet"), f.col("populationsStructure")
+                ),
+            )
+            # Aggregate weighted R information using ancestry proportions
+            .withColumn(
+                "ldSet",
+                self._calculate_weighted_r_overall(f.col("ldSet")),
             )
         )
-
-    @classmethod
-    def ld_annotation_by_locus_ancestry(
-        cls: type[LDAnnotatorGnomad],
-        session: Session,
-        associations: StudyLocusGWASCatalog,
-        studies: StudyIndexGWASCatalog,
-        ld_populations: list[str],
-        ld_index_template: str,
-        ld_matrix_template: str,
-        min_r2: float,
-    ) -> DataFrame:
-        """LD information for all locus and ancestries.
-
-        Args:
-            session (Session): Session
-            associations (StudyLocusGWASCatalog): GWAS associations
-            studies (StudyIndexGWASCatalog): study metadata of the associations
-            ld_populations (list[str]): List of populations to annotate
-            ld_index_template (str): Template path of the LD matrix index containing `{POP}` where the population is expected
-            ld_matrix_template (str): Template path of the LD matrix containing `{POP}` where the population is expected
-            min_r2 (float): minimum r2 to keep
-
-        Returns:
-            DataFrame: LD annotation ["variantId", "chromosome", "gnomadPopulation", "tagVariantId", "r"]
-        """
-        # Unique lead - population pairs:
-        locus_ancestry = (
-            associations.unique_study_locus_ancestries(studies)
-            # Ignoring study information / relativeSampleSize to get unique lead-ancestry pairs
-            .drop("studyId", "relativeSampleSize")
-            .distinct()
-            .persist()
-        )
-
-        # All gnomad populations captured in associations:
-        assoc_populations = locus_ancestry.rdd.map(
-            lambda x: x.gnomadPopulation
-        ).collect()
-
-        # Retrieve LD information from gnomAD
-        ld_annotated_assocs = []
-        for population in ld_populations:
-            if population in assoc_populations:
-                pop_parsed_ldindex_path = ld_index_template.format(POP=population)
-                pop_matrix_path = ld_matrix_template.format(POP=population)
-                ld_index = LDIndex.from_parquet(session, pop_parsed_ldindex_path)
-                ld_matrix = BlockMatrix.read(pop_matrix_path)
-                ld_annotated_assocs.append(
-                    LDAnnotatorGnomad.get_ld_annotated_assocs_for_population(
-                        population,
-                        ld_index,
-                        ld_matrix,
-                        locus_ancestry,
-                        min_r2,
-                    ).coalesce(400)
-                )
-        return reduce(DataFrame.unionByName, ld_annotated_assocs)

--- a/src/otg/method/ld.py
+++ b/src/otg/method/ld.py
@@ -64,8 +64,9 @@ class LDAnnotator:
             ),
         )
 
+    @classmethod
     def annotate_variants_with_ld(
-        self: LDAnnotator, variants_df: DataFrame, ld_index: LDIndex
+        cls: type[LDAnnotator], variants_df: DataFrame, ld_index: LDIndex
     ) -> DataFrame:
         """Annotate linkage disequilibrium (LD) information to a set of variants.
 
@@ -78,8 +79,9 @@ class LDAnnotator:
         """
         return variants_df.join(ld_index.df, on=["variantId", "chromosome"], how="left")
 
+    @classmethod
     def annotate_associations_with_ld(
-        self: LDAnnotator,
+        cls: type[LDAnnotator],
         associations_df: DataFrame,
         ld_index: LDIndex,
     ) -> DataFrame:
@@ -103,13 +105,11 @@ class LDAnnotator:
             # Add population size to each rValues entry in the ldSet
             .withColumn(
                 "ldSet",
-                self._add_population_size(
-                    f.col("ldSet"), f.col("populationsStructure")
-                ),
+                cls._add_population_size(f.col("ldSet"), f.col("populationsStructure")),
             )
             # Aggregate weighted R information using ancestry proportions
             .withColumn(
                 "ldSet",
-                self._calculate_weighted_r_overall(f.col("ldSet")),
+                cls._calculate_weighted_r_overall(f.col("ldSet")),
             )
         )

--- a/src/otg/method/ld.py
+++ b/src/otg/method/ld.py
@@ -111,5 +111,5 @@ class LDAnnotator:
             .withColumn(
                 "ldSet",
                 cls._calculate_weighted_r_overall(f.col("ldSet")),
-            )
+            ).drop("populationsStructure")
         )

--- a/src/otg/method/pics.py
+++ b/src/otg/method/pics.py
@@ -94,32 +94,30 @@ class PICS:
         return neglog_p * r2 if r2 >= 0.5 else None
 
     @staticmethod
-    def _finemap(
-        credible_set: list[Row], lead_neglog_p: float, k: float
-    ) -> list | None:
+    def _finemap(ld_set: list[Row], lead_neglog_p: float, k: float) -> list | None:
         """Calculates the probability of a variant being causal in a study-locus context by applying the PICS method.
 
         It is intended to be applied as an UDF in `PICS.finemap`, where each row is a StudyLocus association.
-        The function iterates over every SNP in the `credibleSet` array, and it returns an updated credibleSet with
+        The function iterates over every SNP in the `ldSet` array, and it returns an updated credibleSet with
         its association signal and causality probability as of PICS.
 
         Args:
-            credible_set (list): list of tagging variants after expanding the locus
+            ld_set (list): list of tagging variants after expanding the locus
             lead_neglog_p (float): P value of the association signal between the lead variant and the study in the form of -log10.
             k (float): Empiric constant that can be adjusted to fit the curve, 6.4 recommended.
 
         Returns:
             List of tagging variants with an estimation of the association signal and their posterior probability as of PICS.
         """
-        if credible_set is None:
+        if ld_set is None:
             return None
-        elif not credible_set:
+        elif not ld_set:
             return []
 
         tmp_credible_set = []
         new_credible_set = []
         # First iteration: calculation of mu, standard deviation, and the relative posterior probability
-        for tag_struct in credible_set:
+        for tag_struct in ld_set:
             tag_dict = (
                 tag_struct.asDict()
             )  # tag_struct is of type pyspark.Row, we'll represent it as a dict
@@ -192,8 +190,8 @@ class PICS:
             .withColumn(
                 "credibleSet",
                 f.when(
-                    f.col("credibleSet").isNotNull(),
-                    _finemap_udf(f.col("credibleSet"), f.col("neglog_pvalue")),
+                    f.col("ldSet").isNotNull(),
+                    _finemap_udf(f.col("ldSet"), f.col("neglog_pvalue")),
                 ),
             )
             .drop("neglog_pvalue")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -420,21 +420,6 @@ def mock_ld_index(spark: SparkSession) -> LDIndex:
             randomSeedMethod="hash_fieldname",
         )
         .withSchema(ld_schema)
-        .withColumnSpec("variantId", expr="cast(rand() as string)")
-        .withColumnSpec(
-            "ldSet",
-            expr="array(named_struct('tagVariantId', cast(rand() as string), 'rValues', array(named_struct('r', cast(rand() as float), 'population', cast(rand() as string)))))",
-        )
-    )
-    data_spec = (
-        dg.DataGenerator(
-            spark,
-            rows=400,
-            partitions=4,
-            randomSeedMethod="hash_fieldname",
-        )
-        .withSchema(ld_schema)
-        .withColumnSpec("variantId", expr="cast(rand() as string)")
         .withColumnSpec(
             "ldSet",
             expr="array(named_struct('tagVariantId', cast(rand() as string), 'rValues', array(named_struct('population', cast(rand() as string), 'r', cast(rand() as double)))))",

--- a/tests/dataset/test_study_index.py
+++ b/tests/dataset/test_study_index.py
@@ -42,15 +42,6 @@ def test_study_index_type_lut(mock_study_index: StudyIndex) -> None:
     assert isinstance(mock_study_index.study_type_lut(), DataFrame)
 
 
-def test_study_gnomad_ancestry_sample_sizes(
-    mock_study_index_gwas_catalog: StudyIndexGWASCatalog,
-) -> None:
-    """Test study index gnomad ancestry sample sizes."""
-    assert isinstance(
-        mock_study_index_gwas_catalog.get_gnomad_ancestry_sample_sizes(), DataFrame
-    )
-
-
 def test_annotate_discovery_sample_sizes(
     mock_study_index_gwas_catalog: StudyIndexGWASCatalog,
 ) -> None:

--- a/tests/dataset/test_study_locus.py
+++ b/tests/dataset/test_study_locus.py
@@ -24,6 +24,7 @@ from otg.dataset.study_locus import (
 )
 
 if TYPE_CHECKING:
+    from otg.dataset.ld_index import LDIndex
     from otg.dataset.study_index import StudyIndex, StudyIndexGWASCatalog
     from otg.dataset.variant_annotation import VariantAnnotation
 
@@ -86,19 +87,25 @@ def test_unique_lead_tag_variants(mock_study_locus: StudyLocus) -> None:
     assert isinstance(mock_study_locus.unique_lead_tag_variants(), DataFrame)
 
 
-def test_unique_study_locus_ancestries(
-    mock_study_locus: StudyLocus, mock_study_index_gwas_catalog: StudyIndexGWASCatalog
-) -> None:
-    """Test study locus ancestries."""
-    assert isinstance(
-        mock_study_locus.unique_study_locus_ancestries(mock_study_index_gwas_catalog),
-        DataFrame,
-    )
-
-
 def test_neglog_pvalue(mock_study_locus: StudyLocus) -> None:
     """Test neglog pvalue."""
     assert isinstance(mock_study_locus.neglog_pvalue(), Column)
+
+
+def test_annotate_ld(
+    mock_study_locus_gwas_catalog: StudyLocusGWASCatalog,
+    mock_study_index_gwas_catalog: StudyIndexGWASCatalog,
+    mock_ld_index: LDIndex,
+) -> None:
+    """Test LD annotation."""
+    # Drop ldSet column to avoid duplicated columns
+    mock_study_locus_gwas_catalog.df = mock_study_locus_gwas_catalog.df.drop("ldSet")
+    assert isinstance(
+        mock_study_locus_gwas_catalog.annotate_ld(
+            mock_study_index_gwas_catalog, mock_ld_index
+        ),
+        StudyLocus,
+    )
 
 
 def test_clump(mock_study_locus: StudyLocus) -> None:

--- a/tests/dataset/test_study_locus.py
+++ b/tests/dataset/test_study_locus.py
@@ -123,10 +123,21 @@ def test_qc_ambiguous_study(
 
 
 def test_qc_unresolved_ld(mock_study_locus_gwas_catalog: StudyLocusGWASCatalog) -> None:
-    """Test qc unresolved ld."""
-    assert isinstance(
-        mock_study_locus_gwas_catalog._qc_unresolved_ld(), StudyLocusGWASCatalog
+    """Test qc unresolved LD by making sure the flag is added when ldSet is null."""
+    mock_study_locus_gwas_catalog.df = mock_study_locus_gwas_catalog.df.filter(
+        f.col("ldSet").isNull()
     )
+    observed_df = (
+        mock_study_locus_gwas_catalog._qc_unresolved_ld()
+        .df.limit(1)
+        .select(
+            f.array_contains(
+                f.col("qualityControls"), "Variant not found in LD reference"
+            )
+        )
+    )
+    expected = True
+    assert observed_df.collect()[0][0] is expected
 
 
 def test_qc_all(sample_gwas_catalog_associations: DataFrame) -> None:

--- a/tests/dataset/test_study_locus.py
+++ b/tests/dataset/test_study_locus.py
@@ -234,18 +234,6 @@ def test_qc_all(sample_gwas_catalog_associations: DataFrame) -> None:
                             "is95CredibleSet": True,
                             "is99CredibleSet": True,
                         },
-                        {
-                            "tagVariantId": "tagVariantB",
-                            "posteriorProbability": 0.01,
-                            "is95CredibleSet": False,
-                            "is99CredibleSet": True,
-                        },
-                        {
-                            "tagVariantId": "tagVariantD",
-                            "posteriorProbability": 0.01,
-                            "is95CredibleSet": False,
-                            "is99CredibleSet": False,
-                        },
                     ],
                 )
             ],

--- a/tests/method/test_ld.py
+++ b/tests/method/test_ld.py
@@ -5,104 +5,123 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import pyspark.sql.functions as f
+import pyspark.sql.types as t
 import pytest
+from pyspark.sql import Row
 
-from otg.method.ld import LDAnnotatorGnomad
+from otg.method.ld import LDAnnotator
 
 if TYPE_CHECKING:
     from pyspark.sql import SparkSession
 
-    from otg.dataset.ld_index import LDIndex
-    from otg.dataset.study_index import StudyIndexGWASCatalog
-    from otg.dataset.study_locus import StudyLocus
-    from otg.dataset.variant_annotation import VariantAnnotation
 
+class TestLDAnnotator:
+    """Test LDAnnotatorGnomad."""
 
-def test_variants_in_ld_in_gnomad_pop(
-    mock_variant_annotation: VariantAnnotation, mock_ld_index: LDIndex
-) -> None:
-    """Test function that annotates which variants are in LD in a particular gnomad population."""
-    variants_w_ld_info = mock_variant_annotation.df.select(
-        "chromosome",
-        "variantId",
-        "position",
-        f.lit("afr").alias("gnomadPopulation"),
-        f.rand().alias("r"),
-        f.rand().alias("j"),
-    )
-    expanded_variants_df = LDAnnotatorGnomad.variants_in_ld_in_gnomad_pop(
-        variants_w_ld_info, mock_ld_index
-    )
-    expected_cols = ["variantId", "chromosome", "gnomadPopulation", "tagVariantId", "r"]
-    assert set(expanded_variants_df.columns) == set(expected_cols)
-
-
-class TestVariantCoordinatesInLdIndex:
-    """Test function that finds the indices of a particular set of variants in a LDIndex to query it afterwards."""
-
-    def test_schema(self: TestVariantCoordinatesInLdIndex) -> None:
-        """Test function that checks the schema of the output of `variant_coordinates_in_ldindex`."""
-        expected_cols = [
-            "variantId",
-            "chromosome",
-            "gnomadPopulation",
-            "idx",
-            "start_idx",
-            "stop_idx",
-            "i",
-        ]
-        assert set(self.variants_w_indices_df.columns) == set(expected_cols)
-
-    def test_idx_order(self: TestVariantCoordinatesInLdIndex) -> None:
-        """Test function that checks that the indices are ordered."""
-        idx_list = (
-            self.variants_w_indices_df.select("idx").rdd.flatMap(lambda x: x).collect()
-        )
-        assert idx_list == sorted(idx_list)
-
-    def test_variants_ld_info(
-        self: TestVariantCoordinatesInLdIndex, spark: SparkSession
+    def test__add_population_size(
+        self: TestLDAnnotator,
     ) -> None:
-        """Tests that the joining function to annotate coordinates and LD scores for a set of variants works."""
-        # scores based on the output of _query_block_matrix
-        variants_ld_scores = spark.createDataFrame(
-            [(0, 0, 0.8), (0, 1, 1.0), (1, 2, 1.0)],
-            ["i", "j", "r"],
+        """Test _add_population_size."""
+        result_df = self.observed_df.select(
+            LDAnnotator._add_population_size(
+                f.col("ldSet"), f.col("populationsStructure")
+            ).alias("ldSet")
         )
+        expected = [0.8, None]
+        for i, row in enumerate(result_df.collect()):
+            assert row["ldSet"][0]["rValues"][i]["relativeSampleSize"] == pytest.approx(
+                expected[i]
+            )
 
-        # coordinate based on the output of _variant_coordinates_in_ldindex
-        variants_ld_indices = self.variants_w_indices_df
-
-        variants_ld_info = variants_ld_scores.join(
-            f.broadcast(variants_ld_indices),
-            on="i",
-            how="inner",
+    def test__calculate_weighted_r_overall(
+        self: TestLDAnnotator,
+    ) -> None:
+        """Test _calculate_weighted_r_overall."""
+        result_df = self.observed_df.withColumn(
+            "ldSet",
+            LDAnnotator._add_population_size(
+                f.col("ldSet"), f.col("populationsStructure")
+            ),
+        ).withColumn("ldSet", LDAnnotator._calculate_weighted_r_overall(f.col("ldSet")))
+        expected = 0.2
+        assert result_df.collect()[0]["ldSet"][0]["r2Overall"] == pytest.approx(
+            expected
         )
-        expected_cols = [
-            "variantId",
-            "chromosome",
-            "gnomadPopulation",
-            "j",
-            "i",
-            "r",
-            "idx",
-            "start_idx",
-            "stop_idx",
-        ]
-        assert set(variants_ld_info.columns) == set(expected_cols)
 
     @pytest.fixture(autouse=True)
-    def _setup(
-        self: TestVariantCoordinatesInLdIndex,
-        mock_study_locus: StudyLocus,
-        mock_study_index_gwas_catalog: StudyIndexGWASCatalog,
-        mock_ld_index: LDIndex,
-    ) -> None:
-        """Prepares the data for the tests."""
-        # variants_df is the result of extracting the unique locus/ancestry pairs
-        self.variants_df = mock_study_locus.unique_study_locus_ancestries(
-            studies=mock_study_index_gwas_catalog
+    def _setup(self: TestLDAnnotator, spark: SparkSession) -> None:
+        """Prepares fixtures for the test."""
+        self.association_w_ld_set_schema = t.StructType(
+            [
+                t.StructField("variantId", t.StringType(), True),
+                t.StructField(
+                    "ldSet",
+                    t.ArrayType(
+                        t.StructType(
+                            [
+                                t.StructField("tagVariantId", t.StringType(), True),
+                                t.StructField(
+                                    "rValues",
+                                    t.ArrayType(
+                                        t.StructType(
+                                            [
+                                                t.StructField(
+                                                    "population", t.StringType(), True
+                                                ),
+                                                t.StructField(
+                                                    "r", t.DoubleType(), True
+                                                ),
+                                            ]
+                                        )
+                                    ),
+                                    True,
+                                ),
+                            ]
+                        )
+                    ),
+                    True,
+                ),
+                t.StructField("studyId", t.StringType(), True),
+                t.StructField(
+                    "populationsStructure",
+                    t.ArrayType(
+                        t.StructType(
+                            [
+                                t.StructField("population", t.StringType(), True),
+                                t.StructField(
+                                    "relativeSampleSize", t.DoubleType(), True
+                                ),
+                            ]
+                        )
+                    ),
+                ),
+            ]
         )
-        self.variants_w_indices_df = LDAnnotatorGnomad._variant_coordinates_in_ldindex(
-            self.variants_df, mock_ld_index
+        observed_data = [
+            Row(
+                variantId="var1",
+                ldSet=[
+                    {
+                        "tagVariantId": "tag1",
+                        "rValues": [
+                            {"population": "pop1", "r": 0.5},
+                            {"population": "pop2", "r": 0.6},
+                        ],
+                    }
+                ],
+                studyId="study1",
+                populationsStructure=[
+                    {
+                        "population": "pop1",
+                        "relativeSampleSize": 0.8,
+                    },
+                    {
+                        "population": "pop3",
+                        "relativeSampleSize": 0.2,
+                    },
+                ],
+            )
+        ]
+        self.observed_df = spark.createDataFrame(
+            observed_data, self.association_w_ld_set_schema
         )

--- a/tests/method/test_pics.py
+++ b/tests/method/test_pics.py
@@ -15,39 +15,33 @@ if TYPE_CHECKING:
     from pyspark.sql.types import StructType
 
 
-def test_pics(mock_study_locus: StudyLocus) -> None:
-    """Test PICS."""
-    assert isinstance(PICS.finemap(mock_study_locus), StudyLocus)
-
-
 class TestFinemap:
     """Test PICS finemap function under different scenarios."""
 
     def test_finemap_pipeline(self: TestFinemap, mock_study_locus: StudyLocus) -> None:
         """Test finemap works with a mock study locus."""
-        observed = PICS.finemap(mock_study_locus)
-        assert isinstance(observed, StudyLocus)
+        assert isinstance(PICS.finemap(mock_study_locus), StudyLocus)
 
     def test_finemap_empty_array(
         self: TestFinemap, mock_study_locus: StudyLocus
     ) -> None:
         """Test finemap works when `credibleSet` is an empty array by returning an empty array."""
         mock_study_locus.df = mock_study_locus.df.withColumn(
-            "credibleSet",
+            "ldSet",
             # empty array following the `credibleSet` schema
-            f.when(f.col("credibleSet").isNull(), f.array()).otherwise(
-                f.col("credibleSet")
-            ),
-        ).filter(f.size("credibleSet") == 0)
+            f.when(f.col("ldSet").isNull(), f.array()).otherwise(f.col("ldSet")),
+        ).filter(f.size("ldSet") == 0)
         observed_df = PICS.finemap(mock_study_locus).df.limit(1)
+        print("TEST_FINEMAP_EMPTY_ARRAY", observed_df.show(truncate=False))
         assert observed_df.collect()[0]["credibleSet"] == []
 
-    def test_finemap_null_credible_set(
+    def test_finemap_null_ld_set(
         self: TestFinemap, mock_study_locus: StudyLocus
     ) -> None:
         """Test how we apply `finemap` when `credibleSet` is null by returning a null field."""
-        mock_study_locus.df = mock_study_locus.df.filter(f.col("credibleSet").isNull())
+        mock_study_locus.df = mock_study_locus.df.filter(f.col("ldSet").isNull())
         observed_df = PICS.finemap(mock_study_locus).df.limit(1)
+        print("TEST_FINEMAP_NULL", observed_df.show(truncate=False))
         assert observed_df.collect()[0]["credibleSet"] is None
 
     def test_finemap_null_r2(
@@ -76,20 +70,11 @@ class TestFinemap:
                 "pics",
                 [
                     (
-                        None,
-                        None,
-                        None,
-                        None,
                         "tagA",
-                        None,
-                        None,
-                        None,
-                        None,
-                        None,
-                        None,
                         None,  # null r2
                     )
                 ],
+                None,
             )
         ]
 
@@ -98,18 +83,19 @@ class TestFinemap:
                 mock_study_locus_null_r2_data, schema=study_locus_schema
             )
         )
-        observed = PICS.finemap(mock_study_locus)
+        observed_df = PICS.finemap(mock_study_locus).df.limit(1)
         # since PICS can't be run, it returns the same content
-        assert observed.df.collect()[0] == mock_study_locus.df.collect()[0]
+        print("TEST_FINEMAP_EMPTY_R2", observed_df.show(truncate=False))
+        assert observed_df.collect()[0] == mock_study_locus.df.collect()[0]
 
 
 def test__finemap() -> None:
     """Test the _finemap UDF with a simple case."""
-    credible_set = [
+    ld_set = [
         Row(variantId="var1", r2Overall=0.8),
         Row(variantId="var2", r2Overall=1),
     ]
-    result = PICS._finemap(credible_set, lead_neglog_p=10.0, k=6.4)
+    result = PICS._finemap(ld_set, lead_neglog_p=10.0, k=6.4)
     expected = [
         {
             "variantId": "var1",

--- a/workflow/dag.yaml
+++ b/workflow/dag.yaml
@@ -1,18 +1,18 @@
-# - id: "my_gene_index"
-# - id: "my_variant_annotation"
+- id: "my_gene_index"
+- id: "my_variant_annotation"
 - id: "my_ld_index"
-# - id: "my_gwas_catalog"
-#   prerequisites:
-#     - "my_variant_annotation"
-#     - "my_ld_index"
-# - id: "my_variant_index"
-#   prerequisites:
-#     - "my_variant_annotation"
-#     - "my_gwas_catalog"
-# - id: "my_v2g"
-#   prerequisites:
-#     - "my_variant_index"
-#     - "my_variant_annotation"
-#     - "my_gene_index"
-# - id: "my_finngen"
-# - id: "my_ukbiobank"
+- id: "my_gwas_catalog"
+  prerequisites:
+    - "my_variant_annotation"
+    - "my_ld_index"
+- id: "my_variant_index"
+  prerequisites:
+    - "my_variant_annotation"
+    - "my_gwas_catalog"
+- id: "my_v2g"
+  prerequisites:
+    - "my_variant_index"
+    - "my_variant_annotation"
+    - "my_gene_index"
+- id: "my_finngen"
+- id: "my_ukbiobank"

--- a/workflow/dag.yaml
+++ b/workflow/dag.yaml
@@ -1,18 +1,18 @@
-- id: "my_gene_index"
-- id: "my_variant_annotation"
+# - id: "my_gene_index"
+# - id: "my_variant_annotation"
 - id: "my_ld_index"
-- id: "my_gwas_catalog"
-  prerequisites:
-    - "my_variant_annotation"
-    - "my_ld_index"
-- id: "my_variant_index"
-  prerequisites:
-    - "my_variant_annotation"
-    - "my_gwas_catalog"
-- id: "my_v2g"
-  prerequisites:
-    - "my_variant_index"
-    - "my_variant_annotation"
-    - "my_gene_index"
-- id: "my_finngen"
-- id: "my_ukbiobank"
+# - id: "my_gwas_catalog"
+#   prerequisites:
+#     - "my_variant_annotation"
+#     - "my_ld_index"
+# - id: "my_variant_index"
+#   prerequisites:
+#     - "my_variant_annotation"
+#     - "my_gwas_catalog"
+# - id: "my_v2g"
+#   prerequisites:
+#     - "my_variant_index"
+#     - "my_variant_annotation"
+#     - "my_gene_index"
+# - id: "my_finngen"
+# - id: "my_ukbiobank"


### PR DESCRIPTION
This PR contains:
- Logic for the new LDAnnotator, based on the work described here https://github.com/opentargets/issues/issues/3020#issuecomment-1636053704
- Logic changes to assign an LD set to every GWAS Catalog curate study/locus pairs. We now have 2 fields to differentiate the result of expanding the locus (`ldSet`) from the variants that belong to the credible set (`credibleSet`). The latter one is a subset of `ldSet`. 
- Adaptation of PICS.finemap 
- Minor bugs

The new GWASCatalog step runs in 12 minutes (as opposed to > 2h previously) and it is much simpler to follow. 
Some stats from the latest data (available at `gs://genetics_etl_python_playground/output/python_etl/parquet/XX.XX/catalog_study_locus`)
- 434,351 associations
- 47,326 associations with a null ldSet because they involve variants outside the LDIndex. This is now appropriately flagged.
- Among the associations with LD information, some stats about the sizes of the ldSet array (`sizeLd`) vs the credibleSet array (`credibleSet`) say that the average number of tagging variants is ~60, whereas after finemapping, if we stick to only the ones from the 95% credible set, the average size is below 1*.
```
+-------+-----------------+------------------+
|summary|           sizeLd|            sizeCs|
+-------+-----------------+------------------+
|  count|           387025|            387025|
|   mean|62.03514760028422|0.9171939797170725|
| stddev|161.1866631616384|2.5366012217228615|
|    min|                0|                 0|
|    max|             4366|              1187|
+-------+-----------------+------------------+
```
- This basically means that most of the credible sets are formed by a single variant (the lead SNP). This is true for 85% of the associations, since the calculated posterior probability is heavily biased by the r2 value. After discussing with Yakov, we've agreed that this is an undesired limitation from PICS, that we can't do much about it, and that it would be a very nice to compare between fine mapping methods once we implement them.

*It is below 1 because there are associations with an empty ldSet when the association has been clumped.

Questions:
- Is there anything we can do to avoid the singular credible sets?
- Is it useful to keep the `ldSet` field? This is basically a list of all tagging variants
- Do we want to empty the `ldSet`s from the clumped associations?