### PR TITLE
Correct formula for PICS standard deviation

### DIFF
--- a/src/otg/method/pics.py
+++ b/src/otg/method/pics.py
@@ -64,7 +64,7 @@ class PICS:
             None
         """
         return (
-            ((1 - (abs(r2) ** 0.5) ** k) ** 0.5) * (neglog_p**0.5) / 2
+            abs(((1 - (abs(r2) ** 0.5) ** k) ** 0.5) * (neglog_p**0.5) / 2)
             if r2 >= 0.5
             else None
         )

--- a/src/otg/method/pics.py
+++ b/src/otg/method/pics.py
@@ -59,12 +59,12 @@ class PICS:
             >>> PICS._pics_standard_deviation(neglog_p=1.0, r2=1.0, k=6.4)
             0.0
             >>> round(PICS._pics_standard_deviation(neglog_p=10.0, r2=0.5, k=6.4), 3)
-            0.143
+            1.493
             >>> print(PICS._pics_standard_deviation(neglog_p=1.0, r2=0.0, k=6.4))
             None
         """
         return (
-            (1 - abs(r2) ** 0.5**k) ** 0.5 * (neglog_p) ** 0.5 / 2
+            ((1 - (abs(r2) ** 0.5) ** k) ** 0.5) * (neglog_p**0.5) / 2
             if r2 >= 0.5
             else None
         )

--- a/tests/method/test_pics.py
+++ b/tests/method/test_pics.py
@@ -101,15 +101,15 @@ def test__finemap() -> None:
             "variantId": "var1",
             "r2Overall": 0.8,
             "tagPValue": 1e-08,
-            "tagStandardError": 0.8294246485510745,
-            "posteriorProbability": 7.068873779583866e-134,
+            "tagStandardError": 0.07420896512708416,
+            "posteriorProbability": 0.07116959886882368,
         },
         {
             "variantId": "var2",
             "r2Overall": 1,
             "tagPValue": 1e-10,
             "tagStandardError": 0.9977000638225533,
-            "posteriorProbability": 1.0,
+            "posteriorProbability": 0.9288304011311763,
         },
     ]
     for idx, tag in enumerate(result):  # type: ignore


### PR DESCRIPTION
The formula used to calculate the PICS standard deviation was wrong due to the numerous parenthesis.
We were calculating this:
![image](https://github.com/opentargets/genetics_etl_python/assets/45119610/93a2d1fc-66c3-4d8f-b9a1-90289fead821)

Instead of what [PICS defines](https://github.com/opentargets/genetics_etl_python/pull/112#issuecomment-1654101846):
![image](https://github.com/opentargets/genetics_etl_python/assets/45119610/8a74525b-e3cc-41fe-a7b6-55b5becd790a)

I am extracting the absolute value of the st. deviation, because the survival function cannot be defined with negative values.
More details and context in this comment https://github.com/opentargets/genetics_etl_python/pull/112#issuecomment-1654101846
