### PR TITLE
Small new features for Dataset

### DIFF
--- a/src/otg/common/session.py
+++ b/src/otg/common/session.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Dict
 
 from pyspark.conf import SparkConf
 from pyspark.sql import SparkSession
@@ -59,17 +59,20 @@ class Session:
         self.logger = Log4j(self.spark)
         self.write_mode = write_mode
 
-    def read_parquet(self: Session, path: str, schema: StructType) -> DataFrame:
+    def read_parquet(
+        self: Session, path: str, schema: StructType, **kwargs: Dict[str, Any]
+    ) -> DataFrame:
         """Reads parquet dataset with a provided schema.
 
         Args:
             path (str): parquet dataset path
             schema (StructType): Spark schema
+            **kwargs: Additional arguments to pass to spark.read.parquet
 
         Returns:
             DataFrame: Dataframe with provided schema
         """
-        return self.spark.read.schema(schema).format("parquet").load(path)
+        return self.spark.read.schema(schema).parquet(path, **kwargs, inferSchema=False)  # type: ignore
 
 
 class Log4j:

--- a/src/otg/dataset/dataset.py
+++ b/src/otg/dataset/dataset.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Dict
 
 from otg.common.schemas import flatten_schema
 
@@ -51,18 +51,12 @@ class Dataset(ABC):
         pass
 
     @classmethod
-    def from_parquet(cls: type[Dataset], session: Session, path: str) -> Dataset:
-        """Reads a parquet file into a Dataset with a given schema.
-
-        Args:
-            session (Session): ETL session
-            path (str): Path to parquet file
-
-        Returns:
-            Dataset: Dataset with given schema
-        """
+    def from_parquet(
+        cls: type[Dataset], session: Session, path: str, **kwargs: Dict[str, Any]
+    ) -> Dataset:
+        """Reads a parquet file into a Dataset with a given schema."""
         schema = cls._get_schema()
-        df = session.read_parquet(path=path, schema=schema)
+        df = session.read_parquet(path=path, schema=schema, **kwargs)
         return cls(_df=df, _schema=schema)
 
     def validate_schema(self: Dataset) -> None:  # sourcery skip: invert-any-all

--- a/src/otg/dataset/dataset.py
+++ b/src/otg/dataset/dataset.py
@@ -106,3 +106,13 @@ class Dataset(ABC):
             raise ValueError(
                 f"The following fields present differences in their datatypes: {fields_with_different_observed_datatype}."
             )
+
+    def persist(self: Dataset) -> Dataset:
+        """Persist in memory the DataFrame included in the Dataset."""
+        self.df = self._df.persist()
+        return self
+
+    def unpersist(self: Dataset) -> Dataset:
+        """Remove the persisted DataFrame from memory."""
+        self.df = self._df.unpersist()
+        return self

--- a/src/otg/dataset/gene_index.py
+++ b/src/otg/dataset/gene_index.py
@@ -1,4 +1,4 @@
-"""Variant index dataset."""
+"""Gene index dataset."""
 from __future__ import annotations
 
 from dataclasses import dataclass

--- a/src/otg/dataset/variant_annotation.py
+++ b/src/otg/dataset/variant_annotation.py
@@ -140,11 +140,6 @@ class VariantAnnotation(Dataset):
             _schema=cls._get_schema(),
         )
 
-    def persist(self: VariantAnnotation) -> VariantAnnotation:
-        """Persist DataFrame included in the Dataset."""
-        self.df = self._df.persist()
-        return self
-
     def max_maf(self: VariantAnnotation) -> Column:
         """Maximum minor allele frequency accross all populations.
 

--- a/src/otg/dataset/variant_index.py
+++ b/src/otg/dataset/variant_index.py
@@ -59,8 +59,3 @@ class VariantIndex(Dataset):
             ),
             _schema=cls._get_schema(),
         )
-
-    def persist(self: VariantIndex) -> VariantIndex:
-        """Persist DataFrame included in the Dataset."""
-        self.df = self._df.persist()
-        return self

--- a/tests/common/test_gwas_catalog_splitter.py
+++ b/tests/common/test_gwas_catalog_splitter.py
@@ -10,7 +10,7 @@ def test_gwas_catalog_splitter_split(
     mock_study_index_gwas_catalog: StudyIndexGWASCatalog,
     mock_study_locus_gwas_catalog: StudyLocusGWASCatalog,
 ) -> None:
-    """Test v2g creation with mock data."""
+    """Test StudyIndexGWASCatalog, StudyLocusGWASCatalog creation with mock data."""
     d1, d2 = GWASCatalogSplitter.split(
         mock_study_index_gwas_catalog, mock_study_locus_gwas_catalog
     )


### PR DESCRIPTION
This PR includes some suggestions from @DSuveges, that are now straightforward with the new abstract class:
- changes to allow for the use of kwargs in `Dataset.from_parquet`.
    - I've tested it with `ds = GeneIndex.from_parquet(session, PATH, recursiveFileLookup=True)` 
    - In general, any argument that can be passed to `spark.read.parquet(...)` can be used
- inclusion of `persist/unpersist` as Dataset methods.
    - Tested it with ` ds.persist() / ds.unpersist()`. Both dfs are persisted/unpersisted, and the method returns the dataset child class.