### PR TITLE
Assign final `studyLocusId` to GWASCat data

### DIFF
--- a/src/otg/common/gwas_catalog_splitter.py
+++ b/src/otg/common/gwas_catalog_splitter.py
@@ -132,5 +132,7 @@ class GWASCatalogSplitter:
                 st_ass.select(
                     "updatedStudyId", "studyId", "subStudyDescription"
                 ).distinct()
-            )._qc_ambiguous_study(),
+            )._qc_ambiguous_study()
+            # Overwrite the temporary studyLocusId and create the final hash
+            ._assign_study_locus_id(),
         )

--- a/src/otg/common/gwas_catalog_splitter.py
+++ b/src/otg/common/gwas_catalog_splitter.py
@@ -7,8 +7,6 @@ from typing import TYPE_CHECKING, Tuple
 import pyspark.sql.functions as f
 from pyspark.sql.window import Window
 
-from otg.dataset.study_locus import StudyLocus
-
 if TYPE_CHECKING:
     from pyspark.sql import Column
 
@@ -134,10 +132,7 @@ class GWASCatalogSplitter:
                 st_ass.select(
                     "updatedStudyId", "studyId", "subStudyDescription"
                 ).distinct()
-            )._qc_ambiguous_study()
-            # Overwrite the temporary studyLocusId and create the final hash
-            .withColumn(
-                "studyLocusId",
-                StudyLocus.assign_study_locus_id(f.col("studyId"), f.col("variantId")),
-            ),
+            )
+            ._qc_ambiguous_study()
+            .assign_study_locus_id(),  # Overwrite the temporary studyLocusId and create the final hash
         )

--- a/src/otg/common/gwas_catalog_splitter.py
+++ b/src/otg/common/gwas_catalog_splitter.py
@@ -132,7 +132,5 @@ class GWASCatalogSplitter:
                 st_ass.select(
                     "updatedStudyId", "studyId", "subStudyDescription"
                 ).distinct()
-            )
-            ._qc_ambiguous_study()
-            .assign_study_locus_id(),  # Overwrite the temporary studyLocusId and create the final hash
+            )._qc_ambiguous_study(),
         )

--- a/src/otg/common/gwas_catalog_splitter.py
+++ b/src/otg/common/gwas_catalog_splitter.py
@@ -7,6 +7,8 @@ from typing import TYPE_CHECKING, Tuple
 import pyspark.sql.functions as f
 from pyspark.sql.window import Window
 
+from otg.dataset.study_locus import StudyLocus
+
 if TYPE_CHECKING:
     from pyspark.sql import Column
 
@@ -134,5 +136,8 @@ class GWASCatalogSplitter:
                 ).distinct()
             )._qc_ambiguous_study()
             # Overwrite the temporary studyLocusId and create the final hash
-            ._assign_study_locus_id(),
+            .withColumn(
+                "studyLocusId",
+                StudyLocus.assign_study_locus_id(f.col("studyId"), f.col("variantId")),
+            ),
         )

--- a/src/otg/common/utils.py
+++ b/src/otg/common/utils.py
@@ -287,28 +287,3 @@ def parse_efos(efo_uri: Column) -> Column:
     """
     colname = efo_uri._jc.toString()  # type: ignore
     return f.array_sort(f.expr(f"regexp_extract_all(`{colname}`, '([A-Z]+_[0-9]+)')"))
-
-
-def get_study_locus_id(study_id_col: Column, variant_id_col: Column) -> Column:
-    """Hashes a column with a variant ID and a study ID to extract a consistent studyLocusId.
-
-    Args:
-        study_id_col (Column): column name with a study ID
-        variant_id_col (Column): column name with a variant ID
-
-    Returns:
-        Column: column with a study locus ID
-
-    Examples:
-        >>> df = spark.createDataFrame([("GCST000001", "1_1000_A_C"), ("GCST000002", "1_1000_A_C")]).toDF("studyId", "variantId")
-        >>> df.withColumn("study_locus_id", get_study_locus_id(*[f.col("variantId"), f.col("studyId")])).show()
-        +----------+----------+--------------------+
-        |   studyId| variantId|      study_locus_id|
-        +----------+----------+--------------------+
-        |GCST000001|1_1000_A_C| 7437284926964690765|
-        |GCST000002|1_1000_A_C|-7653912547667845377|
-        +----------+----------+--------------------+
-        <BLANKLINE>
-
-    """
-    return f.xxhash64(*[study_id_col, variant_id_col]).alias("studyLocusId")

--- a/src/otg/common/utils.py
+++ b/src/otg/common/utils.py
@@ -289,19 +289,19 @@ def parse_efos(efo_uri: Column) -> Column:
     return f.array_sort(f.expr(f"regexp_extract_all(`{colname}`, '([A-Z]+_[0-9]+)')"))
 
 
-def get_study_locus_id(study_id_col_name: str, variant_id_col_name: str) -> Column:
+def get_study_locus_id(study_id_col: Column, variant_id_col: Column) -> Column:
     """Hashes a column with a variant ID and a study ID to extract a consistent studyLocusId.
 
     Args:
-        study_id_col_name (str): column name with a study ID
-        variant_id_col_name (str): column name with a variant ID
+        study_id_col (Column): column name with a study ID
+        variant_id_col (Column): column name with a variant ID
 
     Returns:
         Column: column with a study locus ID
 
     Examples:
         >>> df = spark.createDataFrame([("GCST000001", "1_1000_A_C"), ("GCST000002", "1_1000_A_C")]).toDF("studyId", "variantId")
-        >>> df.withColumn("study_locus_id", get_study_locus_id(*["variantId", "studyId"])).show()
+        >>> df.withColumn("study_locus_id", get_study_locus_id(*[f.col("variantId"), f.col("studyId")])).show()
         +----------+----------+--------------------+
         |   studyId| variantId|      study_locus_id|
         +----------+----------+--------------------+
@@ -311,4 +311,4 @@ def get_study_locus_id(study_id_col_name: str, variant_id_col_name: str) -> Colu
         <BLANKLINE>
 
     """
-    return f.xxhash64(*[study_id_col_name, variant_id_col_name]).alias("studyLocusId")
+    return f.xxhash64(*[study_id_col, variant_id_col]).alias("studyLocusId")

--- a/src/otg/dataset/study_locus.py
+++ b/src/otg/dataset/study_locus.py
@@ -222,7 +222,7 @@ class StudyLocus(Dataset):
         return f.filter(credible_set, lambda x: x["is95CredibleSet"])
 
     @staticmethod
-    def get_study_locus_id(study_id_col: Column, variant_id_col: Column) -> Column:
+    def assign_study_locus_id(study_id_col: Column, variant_id_col: Column) -> Column:
         """Hashes a column with a variant ID and a study ID to extract a consistent studyLocusId.
 
         Args:
@@ -234,7 +234,7 @@ class StudyLocus(Dataset):
 
         Examples:
             >>> df = spark.createDataFrame([("GCST000001", "1_1000_A_C"), ("GCST000002", "1_1000_A_C")]).toDF("studyId", "variantId")
-            >>> df.withColumn("study_locus_id", StudyLocus.get_study_locus_id(*[f.col("variantId"), f.col("studyId")])).show()
+            >>> df.withColumn("study_locus_id", StudyLocus.assign_study_locus_id(*[f.col("variantId"), f.col("studyId")])).show()
             +----------+----------+--------------------+
             |   studyId| variantId|      study_locus_id|
             +----------+----------+--------------------+
@@ -1558,20 +1558,6 @@ class StudyLocusGWASCatalog(StudyLocus):
 
         self.df = LDAnnotator.annotate_associations_with_ld(associations_df, ld_index)
         return self._qc_unresolved_ld()
-
-    def _assign_study_locus_id(self: StudyLocusGWASCatalog) -> StudyLocusGWASCatalog:
-        """Assign a unique study locus id to every association.
-
-        !!! warning "This method must be called after splitting the studies."
-
-        Returns:
-            StudyLocusGWASCatalog: Updated study locus with the final `studyLocusId`.
-        """
-        self.df = self.df.withColumn(
-            "studyLocusId",
-            StudyLocus.get_study_locus_id(f.col("studyId"), f.col("variantId")),
-        )
-        return self
 
     def _qc_ambiguous_study(self: StudyLocusGWASCatalog) -> StudyLocusGWASCatalog:
         """Flag associations with variants that can not be unambiguously associated with one study.

--- a/src/otg/dataset/study_locus.py
+++ b/src/otg/dataset/study_locus.py
@@ -21,7 +21,7 @@ from otg.common.spark_helpers import (
     order_array_of_structs_by_field,
     pvalue_to_zscore,
 )
-from otg.common.utils import get_study_locus_id, parse_efos
+from otg.common.utils import parse_efos
 from otg.dataset.dataset import Dataset
 from otg.dataset.study_locus_overlap import StudyLocusOverlap
 from otg.method.clump import LDclumping
@@ -1568,7 +1568,8 @@ class StudyLocusGWASCatalog(StudyLocus):
             StudyLocusGWASCatalog: Updated study locus with the final `studyLocusId`.
         """
         self.df = self.df.withColumn(
-            "studyLocusId", get_study_locus_id(f.col("studyId"), f.col("variantId"))
+            "studyLocusId",
+            StudyLocus.get_study_locus_id(f.col("studyId"), f.col("variantId")),
         )
         return self
 

--- a/src/otg/dataset/study_locus.py
+++ b/src/otg/dataset/study_locus.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 import pyspark.sql.functions as f
-from pyspark.sql.types import DoubleType, IntegerType, LongType
+from pyspark.sql.types import DoubleType, IntegerType
 from pyspark.sql.window import Window
 
 from otg.assets import data
@@ -21,7 +21,7 @@ from otg.common.spark_helpers import (
     order_array_of_structs_by_field,
     pvalue_to_zscore,
 )
-from otg.common.utils import parse_efos
+from otg.common.utils import get_study_locus_id, parse_efos
 from otg.dataset.dataset import Dataset
 from otg.dataset.study_locus_overlap import StudyLocusOverlap
 from otg.method.clump import LDclumping
@@ -1383,7 +1383,7 @@ class StudyLocusGWASCatalog(StudyLocus):
         """
         return cls(
             _df=gwas_associations.withColumn(
-                "studyLocusId", f.monotonically_increasing_id().cast(LongType())
+                "studyLocusId", get_study_locus_id("variantId", "studyId")
             )
             .transform(
                 # Map/harmonise variants to variant annotation dataset:

--- a/src/otg/dataset/study_locus.py
+++ b/src/otg/dataset/study_locus.py
@@ -221,31 +221,6 @@ class StudyLocus(Dataset):
         """
         return f.filter(credible_set, lambda x: x["is95CredibleSet"])
 
-    @staticmethod
-    def assign_study_locus_id(study_id_col: Column, variant_id_col: Column) -> Column:
-        """Hashes a column with a variant ID and a study ID to extract a consistent studyLocusId.
-
-        Args:
-            study_id_col (Column): column name with a study ID
-            variant_id_col (Column): column name with a variant ID
-
-        Returns:
-            Column: column with a study locus ID
-
-        Examples:
-            >>> df = spark.createDataFrame([("GCST000001", "1_1000_A_C"), ("GCST000002", "1_1000_A_C")]).toDF("studyId", "variantId")
-            >>> df.withColumn("study_locus_id", StudyLocus.assign_study_locus_id(*[f.col("variantId"), f.col("studyId")])).show()
-            +----------+----------+--------------------+
-            |   studyId| variantId|      study_locus_id|
-            +----------+----------+--------------------+
-            |GCST000001|1_1000_A_C| 7437284926964690765|
-            |GCST000002|1_1000_A_C|-7653912547667845377|
-            +----------+----------+--------------------+
-            <BLANKLINE>
-
-        """
-        return f.xxhash64(*[study_id_col, variant_id_col]).alias("studyLocusId")
-
     @classmethod
     def from_parquet(cls: type[StudyLocus], session: Session, path: str) -> StudyLocus:
         """Initialise StudyLocus from parquet file.
@@ -259,6 +234,13 @@ class StudyLocus(Dataset):
         """
         df = session.read_parquet(path=path, schema=cls._schema)
         return cls(_df=df, _schema=cls._schema)
+
+    def assign_study_locus_id(self: StudyLocus) -> StudyLocus:
+        """Hashes a column with a variant ID and a study ID to assign a consistent studyLocusId."""
+        self.df = self._df.withColumn(
+            "studyLocusId", f.xxhash64(*["studyId", "variantId"])
+        )
+        return self
 
     def credible_set(
         self: StudyLocus,

--- a/src/otg/dataset/study_locus.py
+++ b/src/otg/dataset/study_locus.py
@@ -221,6 +221,31 @@ class StudyLocus(Dataset):
         """
         return f.filter(credible_set, lambda x: x["is95CredibleSet"])
 
+    @staticmethod
+    def get_study_locus_id(study_id_col: Column, variant_id_col: Column) -> Column:
+        """Hashes a column with a variant ID and a study ID to extract a consistent studyLocusId.
+
+        Args:
+            study_id_col (Column): column name with a study ID
+            variant_id_col (Column): column name with a variant ID
+
+        Returns:
+            Column: column with a study locus ID
+
+        Examples:
+            >>> df = spark.createDataFrame([("GCST000001", "1_1000_A_C"), ("GCST000002", "1_1000_A_C")]).toDF("studyId", "variantId")
+            >>> df.withColumn("study_locus_id", StudyLocus.get_study_locus_id(*[f.col("variantId"), f.col("studyId")])).show()
+            +----------+----------+--------------------+
+            |   studyId| variantId|      study_locus_id|
+            +----------+----------+--------------------+
+            |GCST000001|1_1000_A_C| 7437284926964690765|
+            |GCST000002|1_1000_A_C|-7653912547667845377|
+            +----------+----------+--------------------+
+            <BLANKLINE>
+
+        """
+        return f.xxhash64(*[study_id_col, variant_id_col]).alias("studyLocusId")
+
     @classmethod
     def from_parquet(cls: type[StudyLocus], session: Session, path: str) -> StudyLocus:
         """Initialise StudyLocus from parquet file.

--- a/src/otg/method/window_based_clumping.py
+++ b/src/otg/method/window_based_clumping.py
@@ -333,4 +333,8 @@ class WindowBasedClumping:
             .select("exploded.*")
             # Dropping helper columns:
             .drop("isLead", "negLogPValue", "cluster_id")
-        ).assign_study_locus_id()
+            .withColumn(
+                "studyLocusId",
+                StudyLocus.assign_study_locus_id(f.col("studyId"), f.col("variantId")),
+            )
+        )

--- a/src/otg/method/window_based_clumping.py
+++ b/src/otg/method/window_based_clumping.py
@@ -335,5 +335,7 @@ class WindowBasedClumping:
             # Dropping helper columns:
             .drop("isLead", "negLogPValue", "cluster_id")
             # assign study-locus id:
-            .withColumn("studyLocusId", get_study_locus_id("studyId", "variantId"))
+            .withColumn(
+                "studyLocusId", get_study_locus_id(f.col("studyId"), f.col("variantId"))
+            )
         )

--- a/src/otg/method/window_based_clumping.py
+++ b/src/otg/method/window_based_clumping.py
@@ -333,9 +333,4 @@ class WindowBasedClumping:
             .select("exploded.*")
             # Dropping helper columns:
             .drop("isLead", "negLogPValue", "cluster_id")
-            # assign study-locus id:
-            .withColumn(
-                "studyLocusId",
-                StudyLocus.assign_study_locus_id(f.col("studyId"), f.col("variantId")),
-            )
-        )
+        ).assign_study_locus_id()

--- a/src/otg/method/window_based_clumping.py
+++ b/src/otg/method/window_based_clumping.py
@@ -336,6 +336,6 @@ class WindowBasedClumping:
             # assign study-locus id:
             .withColumn(
                 "studyLocusId",
-                StudyLocus.get_study_locus_id(f.col("studyId"), f.col("variantId")),
+                StudyLocus.assign_study_locus_id(f.col("studyId"), f.col("variantId")),
             )
         )

--- a/src/otg/method/window_based_clumping.py
+++ b/src/otg/method/window_based_clumping.py
@@ -11,7 +11,6 @@ from pyspark.ml.linalg import DenseVector, VectorUDT
 from pyspark.sql.window import Window
 
 from otg.common.spark_helpers import calculate_neglog_pvalue
-from otg.common.utils import get_study_locus_id
 from otg.dataset.study_locus import StudyLocus
 
 if TYPE_CHECKING:
@@ -336,6 +335,7 @@ class WindowBasedClumping:
             .drop("isLead", "negLogPValue", "cluster_id")
             # assign study-locus id:
             .withColumn(
-                "studyLocusId", get_study_locus_id(f.col("studyId"), f.col("variantId"))
+                "studyLocusId",
+                StudyLocus.get_study_locus_id(f.col("studyId"), f.col("variantId")),
             )
         )


### PR DESCRIPTION
This PR includes:
- minor changes to the GWASCatalog curation parsing that reassigns a new `studyLocusId` that is the product of hashing the variant and study columns
- the process involves creating a temporary `stuydyLocusId` necessary for the steps to parse the input data. At the end, once the studies are splitted, we assign this new final column.

Creating a consistent identifier is important for downstream processed like L2G.
**These edits are made having the `il-ld-annotator` branch as a base (currently under review)** 

New GWASCat index and associations datasets here:
```
gs://genetics_etl_python_playground/output/python_etl/parquet/XX.XX/catalog_study_index/
gs://genetics_etl_python_playground/output/python_etl/parquet/XX.XX/catalog_study_locus/
```