### PR TITLE
feat: add `StudyLocusOverlaps` step to the project

### DIFF
--- a/config/datasets/gcp.yaml
+++ b/config/datasets/gcp.yaml
@@ -31,6 +31,7 @@ gene_index: ${datasets.outputs}/gene_index/gene_index
 variant_annotation: ${datasets.outputs}/variant_annotation
 variant_index: ${datasets.outputs}/variant_index
 study_locus: ${datasets.outputs}/study_locus
+study_locus_overlap: ${datasets.outputs}/study_locus_overlap
 colocalisation: ${datasets.outputs}/colocalisation
 v2g: ${datasets.outputs}/v2g
 ld_index: ${datasets.outputs}/ld_index

--- a/config/step/my_study_locus_overlap.yaml
+++ b/config/step/my_study_locus_overlap.yaml
@@ -2,6 +2,6 @@
 defaults:
   - study_locus_overlap
 # Additional config
-study_locus_path: ${datasets.outputs}/study_locus
+study_locus_path: ${datasets.outputs}/catalog_study_locus
 study_index_path: ${datasets.outputs}/catalog_study_index
-study_locus_overlap_path: ${datasets.outputs}/study_locus_overlap
+overlaps_index_out: ${datasets.outputs}/study_locus_overlap

--- a/config/step/my_study_locus_overlap.yaml
+++ b/config/step/my_study_locus_overlap.yaml
@@ -1,0 +1,7 @@
+# Default config
+defaults:
+  - study_locus_overlap
+# Additional config
+study_locus_path: ${datasets.outputs}/study_locus
+study_index_path: ${datasets.outputs}/catalog_study_index
+study_locus_overlap_path: ${datasets.outputs}/study_locus_overlap

--- a/docs/components/dataset/study_locus_overlap.md
+++ b/docs/components/dataset/study_locus_overlap.md
@@ -1,7 +1,8 @@
-::: otg.dataset.study_locus_overlap.StudyLocusOverlap
-
-___
+# Study Locus Overlap
 
 ## Schema
 
 --8<-- "assets/schemas/study_locus_overlap.md"
+## API
+
+::: otg.dataset.study_locus_overlap.StudyLocusOverlap

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -22,9 +22,9 @@ All pipelines in this repository are intended to be run in Google Dataproc. Runn
 
 In order to run the code:
 
-1. Manually edit your local [`workflow/dag.yaml`](workflow/dag.yaml) file and comment out the steps you do not want to run.
+1. Manually edit your local [`workflow/dag.yaml`](../workflow/dag.yaml) file and comment out the steps you do not want to run.
 
-2. Manually edit your local [`pyproject.toml`](pyproject.toml) file and modify the version of the code.
+2. Manually edit your local [`pyproject.toml`](../pyproject.toml) file and modify the version of the code.
     - This must be different from the version used by any other people working on the repository to avoid any deployment conflicts, so it's a good idea to use your name, for example: `1.2.3+jdoe`.
     - You can also add a brief branch description, for example: `1.2.3+jdoe.myfeature`.
     - Note that the version must comply with [PEP440 conventions](https://peps.python.org/pep-0440/#normalization), otherwise Poetry will not allow it to be deployed.

--- a/src/otg/assets/schemas/study_locus_overlap.json
+++ b/src/otg/assets/schemas/study_locus_overlap.json
@@ -26,27 +26,61 @@
     },
     {
       "metadata": {},
-      "name": "right_logABF",
-      "nullable": true,
-      "type": "double"
-    },
-    {
-      "metadata": {},
-      "name": "left_logABF",
-      "nullable": true,
-      "type": "double"
-    },
-    {
-      "metadata": {},
-      "name": "right_posteriorProbability",
-      "nullable": true,
-      "type": "double"
-    },
-    {
-      "metadata": {},
-      "name": "left_posteriorProbability",
-      "nullable": true,
-      "type": "double"
+      "name": "statistics",
+      "nullable": false,
+      "type": {
+        "fields": [
+          {
+            "metadata": {},
+            "name": "left_negLogPValue",
+            "nullable": true,
+            "type": "double"
+          },
+          {
+            "metadata": {},
+            "name": "right_negLogPValue",
+            "nullable": true,
+            "type": "double"
+          },
+          {
+            "metadata": {},
+            "name": "left_beta",
+            "nullable": true,
+            "type": "double"
+          },
+          {
+            "metadata": {},
+            "name": "right_beta",
+            "nullable": true,
+            "type": "double"
+          },
+          {
+            "metadata": {},
+            "name": "left_logABF",
+            "nullable": true,
+            "type": "double"
+          },
+          {
+            "metadata": {},
+            "name": "right_logABF",
+            "nullable": true,
+            "type": "double"
+          },
+          {
+            "metadata": {},
+            "name": "left_posteriorProbability",
+            "nullable": true,
+            "type": "double"
+          },
+          {
+            "metadata": {},
+            "name": "right_posteriorProbability",
+            "nullable": true,
+            "type": "double"
+          }
+        ],
+        "type": "struct"
+      }
     }
   ],
   "type": "struct"

--- a/src/otg/assets/schemas/study_locus_overlap.json
+++ b/src/otg/assets/schemas/study_locus_overlap.json
@@ -32,25 +32,25 @@
         "fields": [
           {
             "metadata": {},
-            "name": "left_negLogPValue",
+            "name": "left_tagPValue",
             "nullable": true,
             "type": "double"
           },
           {
             "metadata": {},
-            "name": "right_negLogPValue",
+            "name": "right_tagPValue",
             "nullable": true,
             "type": "double"
           },
           {
             "metadata": {},
-            "name": "left_beta",
+            "name": "left_tagBeta",
             "nullable": true,
             "type": "double"
           },
           {
             "metadata": {},
-            "name": "right_beta",
+            "name": "right_tagBeta",
             "nullable": true,
             "type": "double"
           },

--- a/src/otg/config.py
+++ b/src/otg/config.py
@@ -224,6 +224,22 @@ class GWASCatalogStepConfig:
 
 
 @dataclass
+class StudyLocusOverlapStepConfig:
+    """StudyLocus overlaps index step requirements.
+
+    Attributes:
+        study_locus_path (str): Input study-locus path.
+        study_index_path (str): Input study index path to extract the type of study.
+        overlaps_index_out (str): Output overlaps index path.
+    """
+
+    _target_: str = "otg.overlaps.OverlapsIndexStep"
+    study_locus_path: str = MISSING
+    study_index_path: str = MISSING
+    overlaps_index_out: str = MISSING
+
+
+@dataclass
 class GeneIndexStepConfig:
     """Gene index step requirements.
 

--- a/src/otg/config.py
+++ b/src/otg/config.py
@@ -325,3 +325,4 @@ def register_configs() -> None:
         group="step",
         node=GWASCatalogSumstatsPreprocessConfig,
     )
+    cs.store(name="study_locus_overlap", group="step", node=StudyLocusOverlapStepConfig)

--- a/src/otg/dataset/dataset.py
+++ b/src/otg/dataset/dataset.py
@@ -72,11 +72,13 @@ class Dataset:
         observed_fields = flatten_schema(observed_schema)
 
         # Unexpected fields in dataset
-        if unexpected_struct_fields := [
-            x for x in observed_fields if x not in expected_fields
+        if unexpected_field_names := [
+            x.name
+            for x in observed_fields
+            if x.name not in [y.name for y in expected_fields]
         ]:
             raise ValueError(
-                f"The {unexpected_struct_fields} fields are not included in DataFrame schema: {expected_fields}"
+                f"The {unexpected_field_names} fields are not included in DataFrame schema: {expected_fields}"
             )
 
         # Required fields not in dataset
@@ -99,10 +101,17 @@ class Dataset:
             )
 
         # Fields with different datatype
+        observed_field_types = {
+            field.name: type(field.dataType) for field in observed_fields
+        }
+        expected_field_types = {
+            field.name: type(field.dataType) for field in expected_fields
+        }
         if fields_with_different_observed_datatype := [
-            field
-            for field in set(observed_fields)
-            if observed_fields.count(field) != expected_fields.count(field)
+            name
+            for name, observed_type in observed_field_types.items()
+            if name in expected_field_types
+            and observed_type != expected_field_types[name]
         ]:
             raise ValueError(
                 f"The following fields present differences in their datatypes: {fields_with_different_observed_datatype}."

--- a/src/otg/dataset/study_locus.py
+++ b/src/otg/dataset/study_locus.py
@@ -165,16 +165,6 @@ class StudyLocus(Dataset):
                 ],
                 how="outer",
             )
-            # ensures nullable=false for following columns
-            .fillna(
-                value="unknown",
-                subset=[
-                    "chromosome",
-                    "right_studyLocusId",
-                    "left_studyLocusId",
-                    "tagVariantId",
-                ],
-            )
         )
 
     @staticmethod

--- a/src/otg/dataset/study_locus.py
+++ b/src/otg/dataset/study_locus.py
@@ -154,17 +154,26 @@ class StudyLocus(Dataset):
         ).join(peak_overlaps, on=["chromosome", "right_studyLocusId"], how="inner")
 
         # Include information about all tag variants in both study-locus aligned by tag variant id
+        overlaps = overlapping_left.join(
+            overlapping_right,
+            on=[
+                "chromosome",
+                "right_studyLocusId",
+                "left_studyLocusId",
+                "tagVariantId",
+            ],
+            how="outer",
+        ).select(
+            "left_studyLocusId",
+            "right_studyLocusId",
+            "chromosome",
+            "tagVariantId",
+            f.struct(
+                *[f"left_{e}" for e in stats_cols] + [f"right_{e}" for e in stats_cols]
+            ).alias("statistics"),
+        )
         return StudyLocusOverlap(
-            _df=overlapping_left.join(
-                overlapping_right,
-                on=[
-                    "chromosome",
-                    "right_studyLocusId",
-                    "left_studyLocusId",
-                    "tagVariantId",
-                ],
-                how="outer",
-            )
+            _df=overlaps,
         )
 
     @staticmethod

--- a/src/otg/dataset/study_locus.py
+++ b/src/otg/dataset/study_locus.py
@@ -137,12 +137,12 @@ class StudyLocus(Dataset):
             StudyLocusOverlap: Pairs of overlapping study-locus with aligned tags.
         """
         # Complete information about all tags in the left study-locus of the overlap
+        stats_cols = ["logABF", "posteriorProbability", "tagPValue", "tagBeta"]
         overlapping_left = credset_to_overlap.select(
             f.col("chromosome"),
             f.col("tagVariantId"),
             f.col("studyLocusId").alias("left_studyLocusId"),
-            f.col("logABF").alias("left_logABF"),
-            f.col("posteriorProbability").alias("left_posteriorProbability"),
+            *[f.col(col).alias(f"left_{col}") for col in stats_cols],
         ).join(peak_overlaps, on=["chromosome", "left_studyLocusId"], how="inner")
 
         # Complete information about all tags in the right study-locus of the overlap
@@ -150,8 +150,7 @@ class StudyLocus(Dataset):
             f.col("chromosome"),
             f.col("tagVariantId"),
             f.col("studyLocusId").alias("right_studyLocusId"),
-            f.col("logABF").alias("right_logABF"),
-            f.col("posteriorProbability").alias("right_posteriorProbability"),
+            *[f.col(col).alias(f"right_{col}") for col in stats_cols],
         ).join(peak_overlaps, on=["chromosome", "right_studyLocusId"], how="inner")
 
         # Include information about all tag variants in both study-locus aligned by tag variant id
@@ -230,7 +229,7 @@ class StudyLocus(Dataset):
         )
         return self
 
-    def overlaps(self: StudyLocus, study_index: StudyIndex) -> StudyLocusOverlap:
+    def find_overlaps(self: StudyLocus, study_index: StudyIndex) -> StudyLocusOverlap:
         """Calculate overlapping study-locus.
 
         Find overlapping study-locus that share at least one tagging variant. All GWAS-GWAS and all GWAS-Molecular traits are computed with the Molecular traits always
@@ -252,6 +251,8 @@ class StudyLocus(Dataset):
                 f.col("credibleSet.tagVariantId").alias("tagVariantId"),
                 f.col("credibleSet.logABF").alias("logABF"),
                 f.col("credibleSet.posteriorProbability").alias("posteriorProbability"),
+                f.col("credibleSet.tagPValue").alias("tagPValue"),
+                f.col("credibleSet.tagBeta").alias("tagBeta"),
             )
             .persist()
         )

--- a/src/otg/dataset/study_locus_overlap.py
+++ b/src/otg/dataset/study_locus_overlap.py
@@ -11,13 +11,19 @@ if TYPE_CHECKING:
     from pyspark.sql.types import StructType
 
     from otg.common.session import Session
+    from otg.dataset.study_index import StudyIndex
+    from otg.dataset.study_locus import StudyLocus
 
 
 @dataclass
 class StudyLocusOverlap(Dataset):
     """Study-Locus overlap.
 
-    This dataset captures pairs of overlapping `StudyLocus`.
+    This dataset captures pairs of overlapping `StudyLocus`: that is associations whose credible sets share at least one tagging variant.
+
+    This is a helpful dataset for other downstream analyses, such as colocalisation.
+
+    !!! note
     """
 
     _schema: StructType = parse_spark_schema("study_locus_overlap.json")
@@ -37,3 +43,18 @@ class StudyLocusOverlap(Dataset):
         """
         df = session.read_parquet(path=path, schema=cls._schema)
         return cls(_df=df, _schema=cls._schema)
+
+    @classmethod
+    def from_associations(
+        cls: type[StudyLocusOverlap], study_locus: StudyLocus, study_index: StudyIndex
+    ) -> StudyLocusOverlap:
+        """Initialise StudyLocusOverlap from associations.
+
+        Args:
+            study_locus (StudyLocus): Study-locus associations to find the overlapping signals
+            study_index (StudyIndex): Study index to find the overlapping signals
+
+        Returns:
+            StudyLocusOverlap: Study-locus overlap dataset
+        """
+        return study_locus.find_overlaps(study_index)

--- a/src/otg/dataset/study_locus_overlap.py
+++ b/src/otg/dataset/study_locus_overlap.py
@@ -21,9 +21,8 @@ class StudyLocusOverlap(Dataset):
 
     This dataset captures pairs of overlapping `StudyLocus`: that is associations whose credible sets share at least one tagging variant.
 
-    This is a helpful dataset for other downstream analyses, such as colocalisation.
-
     !!! note
+        This is a helpful dataset for other downstream analyses, such as colocalisation. This dataset will contain the overlapping signals between studyLocus associations once they have been clumped and fine-mapped.
     """
 
     _schema: StructType = parse_spark_schema("study_locus_overlap.json")
@@ -48,7 +47,7 @@ class StudyLocusOverlap(Dataset):
     def from_associations(
         cls: type[StudyLocusOverlap], study_locus: StudyLocus, study_index: StudyIndex
     ) -> StudyLocusOverlap:
-        """Initialise StudyLocusOverlap from associations.
+        """Find the overlapping signals in a particular set of associations (StudyLocus dataset).
 
         Args:
             study_locus (StudyLocus): Study-locus associations to find the overlapping signals

--- a/src/otg/gene_index.py
+++ b/src/otg/gene_index.py
@@ -1,4 +1,4 @@
-"""Step to generate variant index dataset."""
+"""Step to generate gene index dataset."""
 from __future__ import annotations
 
 from dataclasses import dataclass

--- a/src/otg/method/colocalisation.py
+++ b/src/otg/method/colocalisation.py
@@ -71,8 +71,8 @@ class ECaviar:
                 overlapping_signals.df.withColumn(
                     "clpp",
                     ECaviar._get_clpp(
-                        f.col("left_posteriorProbability"),
-                        f.col("right_posteriorProbability"),
+                        f.col("statistics.left_posteriorProbability"),
+                        f.col("statistics.right_posteriorProbability"),
                     ),
                 )
                 .groupBy("left_studyLocusId", "right_studyLocusId", "chromosome")
@@ -170,19 +170,22 @@ class Coloc:
             _df=(
                 overlapping_signals.df
                 # Before summing log_abf columns nulls need to be filled with 0:
-                .fillna(0, subset=["left_logABF", "right_logABF"])
+                .fillna(0, subset=["statistics.left_logABF", "statistics.right_logABF"])
                 # Sum of log_abfs for each pair of signals
-                .withColumn("sum_log_abf", f.col("left_logABF") + f.col("right_logABF"))
+                .withColumn(
+                    "sum_log_abf",
+                    f.col("statistics.left_logABF") + f.col("statistics.right_logABF"),
+                )
                 # Group by overlapping peak and generating dense vectors of log_abf:
                 .groupBy("chromosome", "left_studyLocusId", "right_studyLocusId")
                 .agg(
                     f.count("*").alias("coloc_n_vars"),
-                    fml.array_to_vector(f.collect_list(f.col("left_logABF"))).alias(
-                        "left_logABF"
-                    ),
-                    fml.array_to_vector(f.collect_list(f.col("right_logABF"))).alias(
-                        "right_logABF"
-                    ),
+                    fml.array_to_vector(
+                        f.collect_list(f.col("statistics.left_logABF"))
+                    ).alias("left_logABF"),
+                    fml.array_to_vector(
+                        f.collect_list(f.col("statistics.right_logABF"))
+                    ).alias("right_logABF"),
                     fml.array_to_vector(f.collect_list(f.col("sum_log_abf"))).alias(
                         "sum_log_abf"
                     ),

--- a/src/otg/overlaps.py
+++ b/src/otg/overlaps.py
@@ -20,7 +20,11 @@ class OverlapsIndexStep(StudyLocusOverlapStepConfig):
     session: Session = Session()
 
     def run(self: OverlapsIndexStep) -> None:
-        """Run Overlaps index step."""
+        """Run Overlaps index step.
+
+        !!! note
+            This dataset is defined to contain the overlapping signals between studyLocus associations once they have been clumped and fine-mapped.
+        """
         # Extract
         study_locus = StudyLocus.from_parquet(self.session, self.study_locus_path)
         study_index = StudyIndex.from_parquet(self.session, self.study_index_path)

--- a/src/otg/overlaps.py
+++ b/src/otg/overlaps.py
@@ -1,0 +1,32 @@
+"""Step to generate the dataset of overlapping studyLocus associations."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from otg.common.session import Session
+from otg.config import StudyLocusOverlapStepConfig
+from otg.dataset.study_index import StudyIndex
+from otg.dataset.study_locus import StudyLocus
+from otg.dataset.study_locus_overlap import StudyLocusOverlap
+
+
+@dataclass
+class OverlapsIndexStep(StudyLocusOverlapStepConfig):
+    """StudyLocus overlaps step.
+
+    This step generates a dataset of overlapping studyLocus associations.
+    """
+
+    session: Session = Session()
+
+    def run(self: OverlapsIndexStep) -> None:
+        """Run Overlaps index step."""
+        # Extract
+        study_locus = StudyLocus.from_parquet(self.session, self.study_locus_path)
+        study_index = StudyIndex.from_parquet(self.session, self.study_index_path)
+        # Transform
+        overlaps_index = StudyLocusOverlap.from_associations(study_locus, study_index)
+        # Load
+        overlaps_index.df.write.mode(self.session.write_mode).parquet(
+            self.overlaps_index_out
+        )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -169,19 +169,12 @@ def mock_study_locus_overlap(spark: SparkSession) -> StudyLocusOverlap:
     """Mock StudyLocusOverlap dataset."""
     schema = parse_spark_schema("study_locus_overlap.json")
 
-    data_spec = (
-        dg.DataGenerator(
-            spark,
-            rows=400,
-            partitions=4,
-            randomSeedMethod="hash_fieldname",
-        )
-        .withSchema(schema)
-        .withColumnSpec("right_logABF", percentNulls=0.1)
-        .withColumnSpec("left_logABF", percentNulls=0.1)
-        .withColumnSpec("right_posteriorProbability", percentNulls=0.1)
-        .withColumnSpec("left_posteriorProbability", percentNulls=0.1)
-    )
+    data_spec = dg.DataGenerator(
+        spark,
+        rows=400,
+        partitions=4,
+        randomSeedMethod="hash_fieldname",
+    ).withSchema(schema)
 
     return StudyLocusOverlap(_df=data_spec.build(), _schema=schema)
 

--- a/tests/dataset/test_study_locus.py
+++ b/tests/dataset/test_study_locus.py
@@ -73,7 +73,9 @@ def test_study_locus_overlaps(
     mock_study_locus: StudyLocus, mock_study_index: StudyIndex
 ) -> None:
     """Test study locus overlaps."""
-    assert isinstance(mock_study_locus.overlaps(mock_study_index), StudyLocusOverlap)
+    assert isinstance(
+        mock_study_locus.find_overlaps(mock_study_index), StudyLocusOverlap
+    )
 
 
 def test_credible_set(mock_study_locus: StudyLocus) -> None:

--- a/tests/dataset/test_study_locus_overlaps.py
+++ b/tests/dataset/test_study_locus_overlaps.py
@@ -1,7 +1,13 @@
 """Test colocalisation dataset."""
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from otg.dataset.study_locus_overlap import StudyLocusOverlap
+
+if TYPE_CHECKING:
+    from otg.dataset.study_index import StudyIndex
+    from otg.dataset.study_locus import StudyLocus
 
 
 def test_study_locus_overlap_creation(
@@ -9,3 +15,11 @@ def test_study_locus_overlap_creation(
 ) -> None:
     """Test colocalisation creation with mock data."""
     assert isinstance(mock_study_locus_overlap, StudyLocusOverlap)
+
+
+def test_study_locus_overlap_from_associations(
+    mock_study_locus: StudyLocus, mock_study_index: StudyIndex
+) -> None:
+    """Test colocalisation creation from mock associations."""
+    overlaps = StudyLocusOverlap.from_associations(mock_study_locus, mock_study_index)
+    assert isinstance(overlaps, StudyLocusOverlap)

--- a/tests/dataset/test_study_locus_overlaps.py
+++ b/tests/dataset/test_study_locus_overlaps.py
@@ -3,11 +3,16 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+import pyspark.sql.types as t
+import pytest
+
+from otg.dataset.study_locus import StudyLocus
 from otg.dataset.study_locus_overlap import StudyLocusOverlap
 
 if TYPE_CHECKING:
+    from pyspark.sql import SparkSession
+
     from otg.dataset.study_index import StudyIndex
-    from otg.dataset.study_locus import StudyLocus
 
 
 def test_study_locus_overlap_creation(
@@ -23,3 +28,60 @@ def test_study_locus_overlap_from_associations(
     """Test colocalisation creation from mock associations."""
     overlaps = StudyLocusOverlap.from_associations(mock_study_locus, mock_study_index)
     assert isinstance(overlaps, StudyLocusOverlap)
+
+
+@pytest.mark.parametrize(
+    ("observed", "expected"),
+    [
+        (
+            # observed - input DataFrame representing gwas and nongwas data to find overlapping signals
+            [
+                {
+                    "studyLocusId": 1,
+                    "studyType": "gwas",
+                    "chromosome": "1",
+                    "tagVariantId": "A",
+                },
+                {
+                    "studyLocusId": 2,
+                    "studyType": "eqtl",
+                    "chromosome": "1",
+                    "tagVariantId": "A",
+                },
+                {
+                    "studyLocusId": 3,
+                    "studyType": "gwas",
+                    "chromosome": "1",
+                    "tagVariantId": "B",
+                },
+            ],
+            # expected - output DataFrame with overlapping signals
+            [
+                {"left_studyLocusId": 1, "right_studyLocusId": 2, "chromosome": "1"},
+            ],
+        ),
+    ],
+)
+def test_overlapping_peaks(spark: SparkSession, observed: list, expected: list) -> None:
+    """Test overlapping signals between GWAS-GWAS and GWAS-Molecular trait to make sure that mQTLs are always on the right."""
+    mock_schema = t.StructType(
+        [
+            t.StructField("studyLocusId", t.LongType()),
+            t.StructField("studyType", t.StringType()),
+            t.StructField("chromosome", t.StringType()),
+            t.StructField("tagVariantId", t.StringType()),
+        ]
+    )
+    expected_schema = t.StructType(
+        [
+            t.StructField("left_studyLocusId", t.LongType()),
+            t.StructField("right_studyLocusId", t.LongType()),
+            t.StructField("chromosome", t.StringType()),
+        ]
+    )
+    observed_df = spark.createDataFrame(observed, mock_schema)
+    result_df = StudyLocus._overlapping_peaks(observed_df)
+    expected_df = spark.createDataFrame(expected, expected_schema)
+    print("RESULT", result_df.show())
+    print("EXPECTED", expected_df.show())
+    assert result_df.collect() == expected_df.collect()


### PR DESCRIPTION
This PR contains the code necessary to output a dataset of overlapping signals that share common variants in their credible sets.

## Context
The initial purpose was to help @xyg123 use this as part of his pattern based colocalisation. Based on the discussion, I've learnt today that this is not the case for 2 main reasons:
- At this stage of the process we don't have credible sets, as this is a preliminary step to identify common signals prior to finemapping
- The proposed method, SMR-Theta, calculates the overlaps by looking at all variants in the region - so it is distance-based, rather than LD-based.
So this definition of an overlap dataset will fit in a different branch of work, and will have its own specification in a separate ticket.

The scope of this specific dataset is then to generate data to follow what we currently do in production (f[or example](https://genetics.opentargets.org/study-locus/GCST004365_195/1_154445939_T_C), last widget). Regardless of whether we decide to display it or not, it has use as input in the COLOC and eCAVIAR application.

## Features
- Updated the schema to include all statistics related to the tagging variant. This now lives in a `statistics` struct that we are carriying over to be used later on in coloc.
    - This field is technically redundant, since we have here metadata from summary statistics. Given the effort in describing what a locus consists along its metadata ([#3045](https://github.com/opentargets/issues/issues/3045)), we could drop this field. Later on, if we need to know what is the beta of a specific tagging variant, we go back to the studyLocus dataset.
- No breaking changes in downstream processes (coloc and ecaviar)

## Comments
- As suggested, this step assumes that all studyLocus and study indices can be loaded from a single path respectively. That is not the case as of today.
For the studies we have:
```
- /XX.XX/ukbiobank_study_index
- XX.XX/finngen_study_index
- XX.XX/catalog_study_index
```
I'd rather have a single bucket pointing to a datatype such as:
```
- /XX.XX/study_index
    - XX.XX/study_index/finngen_study_index
    - XX.XX/study_index/catalog_study_index
```
(same goes for studyloci)

## QC
 So far, I've prototyped the logic by looking at the overlaps in the GWASCatalog top hits. This is what is available here: `gs://genetics_etl_python_playground/output/python_etl/parquet/XX.XX/study_locus_overlap`. Some stats:
- 2,353,100 rows that represent the 2 overlapping studyLocusIds + the common tagging variant
- 2,121,633 distinct pairs of studyLocusIds
