### PR TITLE
Rename locus columns (no tags)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,7 +84,7 @@ color = true
 exclude = ["dist"]
 
 [tool.pytest.ini_options]
- addopts = "-n auto --doctest-modules --cov=src/ --cov-report=xml"
+addopts = "-n auto --doctest-modules --cov=src/ --cov-report=xml"
 
 [[tool.mypy.overrides]]
 module = "google.protobuf.duration_pb2"

--- a/src/otg/assets/schemas/study_locus.json
+++ b/src/otg/assets/schemas/study_locus.json
@@ -172,43 +172,55 @@
             },
             {
               "metadata": {},
-              "name": "tagVariantId",
+              "name": "variantId",
               "nullable": true,
               "type": "string"
             },
             {
               "metadata": {},
-              "name": "tagPValue",
+              "name": "pValueMantissa",
+              "nullable": true,
+              "type": "float"
+            },
+            {
+              "metadata": {},
+              "name": "pValueExponent",
+              "nullable": true,
+              "type": "integer"
+            },
+            {
+              "metadata": {},
+              "name": "pValueMantissaConditioned",
+              "nullable": true,
+              "type": "float"
+            },
+            {
+              "metadata": {},
+              "name": "pValueExponentConditioned",
+              "nullable": true,
+              "type": "integer"
+            },
+            {
+              "metadata": {},
+              "name": "beta",
               "nullable": true,
               "type": "double"
             },
             {
               "metadata": {},
-              "name": "tagPValueConditioned",
+              "name": "standardError",
               "nullable": true,
               "type": "double"
             },
             {
               "metadata": {},
-              "name": "tagBeta",
+              "name": "betaConditioned",
               "nullable": true,
               "type": "double"
             },
             {
               "metadata": {},
-              "name": "tagStandardError",
-              "nullable": true,
-              "type": "double"
-            },
-            {
-              "metadata": {},
-              "name": "tagBetaConditioned",
-              "nullable": true,
-              "type": "double"
-            },
-            {
-              "metadata": {},
-              "name": "tagStandardErrorConditioned",
+              "name": "standardErrorConditioned",
               "nullable": true,
               "type": "double"
             },

--- a/src/otg/assets/schemas/study_locus_overlap.json
+++ b/src/otg/assets/schemas/study_locus_overlap.json
@@ -44,13 +44,13 @@
           },
           {
             "metadata": {},
-            "name": "left_tagBeta",
+            "name": "left_beta",
             "nullable": true,
             "type": "double"
           },
           {
             "metadata": {},
-            "name": "right_tagBeta",
+            "name": "right_beta",
             "nullable": true,
             "type": "double"
           },

--- a/src/otg/assets/schemas/study_locus_overlap.json
+++ b/src/otg/assets/schemas/study_locus_overlap.json
@@ -32,15 +32,27 @@
         "fields": [
           {
             "metadata": {},
-            "name": "left_tagPValue",
+            "name": "left_pValueMantissa",
             "nullable": true,
-            "type": "double"
+            "type": "float"
           },
           {
             "metadata": {},
-            "name": "right_tagPValue",
+            "name": "left_pValueExponent",
             "nullable": true,
-            "type": "double"
+            "type": "integer"
+          },
+          {
+            "metadata": {},
+            "name": "right_pValueMantissa",
+            "nullable": true,
+            "type": "float"
+          },
+          {
+            "metadata": {},
+            "name": "right_pValueExponent",
+            "nullable": true,
+            "type": "integer"
           },
           {
             "metadata": {},

--- a/src/otg/common/schemas.py
+++ b/src/otg/common/schemas.py
@@ -40,12 +40,12 @@ def flatten_schema(schema: StructType, prefix: str = "") -> list:
         >>> schema = StructType(
         ...     [
         ...        StructField("studyLocusId", StringType(), False),
-        ...        StructField("locus", ArrayType(StructType([StructField("tagVariantId", StringType(), False)])), False)
+        ...        StructField("locus", ArrayType(StructType([StructField("variantId", StringType(), False)])), False)
         ...    ]
         ... )
-        >>> df = spark.createDataFrame([("A", [{"tagVariantId": "varA"}]), ("B", [{"tagVariantId": "varB"}])], schema)
+        >>> df = spark.createDataFrame([("A", [{"variantId": "varA"}]), ("B", [{"variantId": "varB"}])], schema)
         >>> flatten_schema(df.schema)
-        [Field(name='studyLocusId', dataType=StringType()), Field(name='locus', dataType=ArrayType(StructType([]), True)), Field(name='locus.tagVariantId', dataType=StringType())]
+        [Field(name='studyLocusId', dataType=StringType()), Field(name='locus', dataType=ArrayType(StructType([]), True)), Field(name='locus.variantId', dataType=StringType())]
     """
     Field = namedtuple("Field", ["name", "dataType"])
     fields = []

--- a/src/otg/common/utils.py
+++ b/src/otg/common/utils.py
@@ -256,7 +256,20 @@ def split_pvalue(pvalue: float) -> tuple[float, int]:
 
     Returns:
         tuple[float, int]: Tuple with mantissa and exponent
+
+    Examples:
+        >>> split_pvalue(0.00001234)
+        (1.234, -5)
+
+        >>> split_pvalue(1)
+        (1.0, 0)
+
+        >>> split_pvalue(0.123)
+        (1.23, -1)
     """
+    if pvalue < 0.0 or pvalue > 1.0:
+        raise ValueError("P-value must be between 0 and 1")
+
     exponent = floor(log10(pvalue)) if pvalue != 0 else 0
     mantissa = round(pvalue / 10**exponent, 3)
     return (mantissa, exponent)

--- a/src/otg/dataset/study_locus.py
+++ b/src/otg/dataset/study_locus.py
@@ -135,7 +135,7 @@ class StudyLocus(Dataset):
             StudyLocusOverlap: Pairs of overlapping study-locus with aligned tags.
         """
         # Complete information about all tags in the left study-locus of the overlap
-        stats_cols = ["logABF", "posteriorProbability", "tagPValue", "tagBeta"]
+        stats_cols = ["logABF", "posteriorProbability", "tagPValue", "beta"]
         overlapping_left = credset_to_overlap.select(
             f.col("chromosome"),
             f.col("tagVariantId"),
@@ -206,7 +206,7 @@ class StudyLocus(Dataset):
             Column: Filtered credible set column.
 
         Example:
-            >>> df = spark.createDataFrame([([{"tagVariantId": "varA", "is95CredibleSet": True}, {"tagVariantId": "varB", "is95CredibleSet": False}],)], "locus: array<struct<tagVariantId: string, is95CredibleSet: boolean>>")
+            >>> df = spark.createDataFrame([([{"variantId": "varA", "is95CredibleSet": True}, {"variantId": "varB", "is95CredibleSet": False}],)], "locus: array<struct<variantId: string, is95CredibleSet: boolean>>")
             >>> df.select(StudyLocus._filter_credible_set(f.col("locus")).alias("filtered")).show(truncate=False)
             +--------------+
             |filtered      |
@@ -283,11 +283,11 @@ class StudyLocus(Dataset):
                 "studyLocusId",
                 "studyType",
                 "chromosome",
-                f.col("locus.tagVariantId").alias("tagVariantId"),
+                f.col("locus.variantId").alias("tagVariantId"),
                 f.col("locus.logABF").alias("logABF"),
                 f.col("locus.posteriorProbability").alias("posteriorProbability"),
                 f.col("locus.tagPValue").alias("tagPValue"),
-                f.col("locus.tagBeta").alias("tagBeta"),
+                f.col("locus.beta").alias("beta"),
             )
             .persist()
         )

--- a/src/otg/dataset/study_locus.py
+++ b/src/otg/dataset/study_locus.py
@@ -123,20 +123,26 @@ class StudyLocus(Dataset):
 
     @staticmethod
     def _align_overlapping_tags(
-        credset_to_overlap: DataFrame, peak_overlaps: DataFrame
+        loci_to_overlap: DataFrame, peak_overlaps: DataFrame
     ) -> StudyLocusOverlap:
         """Align overlapping tags in pairs of overlapping study-locus, keeping all tags in both loci.
 
         Args:
-            credset_to_overlap (DataFrame): containing `studyLocusId`, `studyType`, `chromosome`, `tagVariantId`, `logABF` and `posteriorProbability` columns.
+            loci_to_overlap (DataFrame): containing `studyLocusId`, `studyType`, `chromosome`, `tagVariantId`, `logABF` and `posteriorProbability` columns.
             peak_overlaps (DataFrame): containing `left_studyLocusId`, `right_studyLocusId` and `chromosome` columns.
 
         Returns:
             StudyLocusOverlap: Pairs of overlapping study-locus with aligned tags.
         """
         # Complete information about all tags in the left study-locus of the overlap
-        stats_cols = ["logABF", "posteriorProbability", "tagPValue", "beta"]
-        overlapping_left = credset_to_overlap.select(
+        stats_cols = [
+            "logABF",
+            "posteriorProbability",
+            "beta",
+            "pValueMantissa",
+            "pValueExponent",
+        ]
+        overlapping_left = loci_to_overlap.select(
             f.col("chromosome"),
             f.col("tagVariantId"),
             f.col("studyLocusId").alias("left_studyLocusId"),
@@ -144,7 +150,7 @@ class StudyLocus(Dataset):
         ).join(peak_overlaps, on=["chromosome", "left_studyLocusId"], how="inner")
 
         # Complete information about all tags in the right study-locus of the overlap
-        overlapping_right = credset_to_overlap.select(
+        overlapping_right = loci_to_overlap.select(
             f.col("chromosome"),
             f.col("tagVariantId"),
             f.col("studyLocusId").alias("right_studyLocusId"),
@@ -276,7 +282,7 @@ class StudyLocus(Dataset):
         Returns:
             StudyLocusOverlap: Pairs of overlapping study-locus with aligned tags.
         """
-        credset_to_overlap = (
+        loci_to_overlap = (
             self.df.join(study_index.study_type_lut(), on="studyId", how="inner")
             .withColumn("locus", f.explode("locus"))
             .select(
@@ -286,17 +292,18 @@ class StudyLocus(Dataset):
                 f.col("locus.variantId").alias("tagVariantId"),
                 f.col("locus.logABF").alias("logABF"),
                 f.col("locus.posteriorProbability").alias("posteriorProbability"),
-                f.col("locus.tagPValue").alias("tagPValue"),
+                f.col("locus.pValueMantissa").alias("pValueMantissa"),
+                f.col("locus.pValueExponent").alias("pValueExponent"),
                 f.col("locus.beta").alias("beta"),
             )
             .persist()
         )
 
         # overlapping study-locus
-        peak_overlaps = self._overlapping_peaks(credset_to_overlap)
+        peak_overlaps = self._overlapping_peaks(loci_to_overlap)
 
         # study-locus overlap by aligning overlapping variants
-        return self._align_overlapping_tags(credset_to_overlap, peak_overlaps)
+        return self._align_overlapping_tags(loci_to_overlap, peak_overlaps)
 
     def unique_lead_tag_variants(self: StudyLocus) -> DataFrame:
         """All unique lead and tag variants contained in the `StudyLocus` dataframe.

--- a/src/otg/method/clump.py
+++ b/src/otg/method/clump.py
@@ -23,7 +23,7 @@ class LDclumping:
         variant_id: Column,
         p_value_exponent: Column,
         p_value_mantissa: Column,
-        credible_set: Column,
+        ld_set: Column,
     ) -> Column:
         """Evaluates whether a lead variant is linked to a tag (with lowest p-value) in the same studyLocus dataset.
 
@@ -32,7 +32,7 @@ class LDclumping:
             variant_id (Column): Lead variant id
             p_value_exponent (Column): p-value exponent
             p_value_mantissa (Column): p-value mantissa
-            credible_set (Column): Credible set <array of structs>
+            locus (Column): Credible set <array of structs>
 
         Returns:
             Column: Boolean in which True indicates that the lead is linked to another tag in the same dataset.
@@ -40,9 +40,9 @@ class LDclumping:
         leads_in_study = f.collect_set(variant_id).over(Window.partitionBy(study_id))
         tags_in_studylocus = f.array_union(
             # Get all tag variants from the credible set per studyLocusId
-            f.transform(credible_set, lambda x: x.tagVariantId),
+            f.transform(ld_set, lambda x: x.tagVariantId),
             # And append the lead variant so that the intersection is the same for all studyLocusIds in a study
-            f.array(f.col("variantId")),
+            f.array(variant_id),
         )
         intersect_lead_tags = f.array_sort(
             f.array_intersect(leads_in_study, tags_in_studylocus)

--- a/src/otg/method/pics.py
+++ b/src/otg/method/pics.py
@@ -8,6 +8,8 @@ import pyspark.sql.functions as f
 import pyspark.sql.types as t
 from scipy.stats import norm
 
+from otg.common.utils import split_pvalue
+
 if TYPE_CHECKING:
     from pyspark.sql import Row
 
@@ -138,8 +140,10 @@ class PICS:
                 posterior_probability = PICS._pics_relative_posterior_probability(
                     lead_neglog_p, pics_snp_mu, pics_snp_std
                 )
-                tag_dict["tagPValue"] = 10**-pics_snp_mu
-                tag_dict["tagStandardError"] = 10**-pics_snp_std
+                mantissa, exponent = split_pvalue(10**-pics_snp_mu)
+                tag_dict["pValueMantissa"] = mantissa
+                tag_dict["pValueExponent"] = exponent
+                tag_dict["standardError"] = 10**-pics_snp_std
                 tag_dict["relativePosteriorProbability"] = posterior_probability
 
                 tmp_credible_set.append(tag_dict)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -213,7 +213,7 @@ def mock_study_locus_data(spark: SparkSession) -> DataFrame:
         .withColumnSpec("finemappingMethod", percentNulls=0.1)
         .withColumnSpec(
             "locus",
-            expr='array(named_struct("is95CredibleSet", cast(rand() > 0.5 as boolean), "is99CredibleSet", cast(rand() > 0.5 as boolean), "logABF", rand(), "posteriorProbability", rand(), "variantId", cast(rand() as string), "p", rand(), "beta", rand(), "standardError", rand(), "betaConditioned", rand(), "standardErrorConditioned", rand(), "r2Overall", rand(), "pValueMantissaConditioned", rand(), "pValueExponentConditioned", rand(), "pValueMantissa", rand(), "pValueExponent", rand()))',
+            expr='array(named_struct("is95CredibleSet", cast(rand() > 0.5 as boolean), "is99CredibleSet", cast(rand() > 0.5 as boolean), "logABF", rand(), "posteriorProbability", rand(), "variantId", cast(rand() as string), "beta", rand(), "standardError", rand(), "betaConditioned", rand(), "standardErrorConditioned", rand(), "r2Overall", rand(), "pValueMantissaConditioned", rand(), "pValueExponentConditioned", rand(), "pValueMantissa", rand(), "pValueExponent", rand()))',
             percentNulls=0.1,
         )
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -213,7 +213,7 @@ def mock_study_locus_data(spark: SparkSession) -> DataFrame:
         .withColumnSpec("finemappingMethod", percentNulls=0.1)
         .withColumnSpec(
             "locus",
-            expr='array(named_struct("is95CredibleSet", cast(rand() > 0.5 as boolean), "is99CredibleSet", cast(rand() > 0.5 as boolean), "logABF", rand(), "posteriorProbability", rand(), "tagVariantId", cast(rand() as string), "tagPValue", rand(), "tagPValueConditioned", rand(), "tagBeta", rand(), "tagStandardError", rand(), "tagBetaConditioned", rand(), "tagStandardErrorConditioned", rand(), "r2Overall", rand()))',
+            expr='array(named_struct("is95CredibleSet", cast(rand() > 0.5 as boolean), "is99CredibleSet", cast(rand() > 0.5 as boolean), "logABF", rand(), "posteriorProbability", rand(), "variantId", cast(rand() as string), "p", rand(), "beta", rand(), "standardError", rand(), "betaConditioned", rand(), "standardErrorConditioned", rand(), "r2Overall", rand(), "pValueMantissaConditioned", rand(), "pValueExponentConditioned", rand(), "pValueMantissa", rand(), "pValueExponent", rand()))',
             percentNulls=0.1,
         )
     )

--- a/tests/dataset/test_study_locus.py
+++ b/tests/dataset/test_study_locus.py
@@ -174,7 +174,7 @@ def test_qc_all(sample_gwas_catalog_associations: DataFrame) -> None:
                     1,
                     "traitA",
                     "leadB",
-                    [{"tagVariantId": "tagVariantA", "posteriorProbability": 1.0}],
+                    [{"variantId": "tagVariantA", "posteriorProbability": 1.0}],
                 ),
             ],
             [
@@ -185,7 +185,7 @@ def test_qc_all(sample_gwas_catalog_associations: DataFrame) -> None:
                     "leadB",
                     [
                         {
-                            "tagVariantId": "tagVariantA",
+                            "variantId": "tagVariantA",
                             "posteriorProbability": 1.0,
                             "is95CredibleSet": True,
                             "is99CredibleSet": True,
@@ -203,11 +203,11 @@ def test_qc_all(sample_gwas_catalog_associations: DataFrame) -> None:
                     "traitA",
                     "leadA",
                     [
-                        {"tagVariantId": "tagVariantA", "posteriorProbability": 0.44},
-                        {"tagVariantId": "tagVariantB", "posteriorProbability": 0.01},
-                        {"tagVariantId": "tagVariantC", "posteriorProbability": 0.04},
-                        {"tagVariantId": "tagVariantD", "posteriorProbability": 0.01},
-                        {"tagVariantId": "tagVariantE", "posteriorProbability": 0.5},
+                        {"variantId": "tagVariantA", "posteriorProbability": 0.44},
+                        {"variantId": "tagVariantB", "posteriorProbability": 0.01},
+                        {"variantId": "tagVariantC", "posteriorProbability": 0.04},
+                        {"variantId": "tagVariantD", "posteriorProbability": 0.01},
+                        {"variantId": "tagVariantE", "posteriorProbability": 0.5},
                     ],
                 )
             ],
@@ -219,19 +219,19 @@ def test_qc_all(sample_gwas_catalog_associations: DataFrame) -> None:
                     "leadA",
                     [
                         {
-                            "tagVariantId": "tagVariantE",
+                            "variantId": "tagVariantE",
                             "posteriorProbability": 0.5,
                             "is95CredibleSet": True,
                             "is99CredibleSet": True,
                         },
                         {
-                            "tagVariantId": "tagVariantA",
+                            "variantId": "tagVariantA",
                             "posteriorProbability": 0.44,
                             "is95CredibleSet": True,
                             "is99CredibleSet": True,
                         },
                         {
-                            "tagVariantId": "tagVariantC",
+                            "variantId": "tagVariantC",
                             "posteriorProbability": 0.04,
                             "is95CredibleSet": True,
                             "is99CredibleSet": True,
@@ -298,7 +298,7 @@ def test_annotate_credible_sets(
                 ArrayType(
                     StructType(
                         [
-                            StructField("tagVariantId", StringType(), True),
+                            StructField("variantId", StringType(), True),
                             StructField("posteriorProbability", DoubleType(), True),
                             StructField("is95CredibleSet", BooleanType(), True),
                             StructField("is99CredibleSet", BooleanType(), True),

--- a/tests/method/test_clump.py
+++ b/tests/method/test_clump.py
@@ -32,7 +32,7 @@ def test_clump(mock_study_locus: StudyLocus) -> None:
                     "GCST005650_1",
                     1.0,
                     -17,
-                    [{"variantId": "T1"}, {"variantId": "L2"}],
+                    [{"tagVariantId": "T1"}, {"tagVariantId": "L2"}],
                     None,
                 ),
                 (
@@ -43,9 +43,9 @@ def test_clump(mock_study_locus: StudyLocus) -> None:
                     4.0,
                     -18,
                     [
-                        {"variantId": "T2"},
-                        {"variantId": "T3"},
-                        {"variantId": "L1"},
+                        {"tagVariantId": "T2"},
+                        {"tagVariantId": "T3"},
+                        {"tagVariantId": "L1"},
                     ],
                     None,
                 ),
@@ -57,9 +57,9 @@ def test_clump(mock_study_locus: StudyLocus) -> None:
                     4.0,
                     -18,
                     [
-                        {"variantId": "L3"},
-                        {"variantId": "T4"},
-                        {"variantId": "L5"},
+                        {"tagVariantId": "L3"},
+                        {"tagVariantId": "T4"},
+                        {"tagVariantId": "L5"},
                     ],
                     None,
                 ),
@@ -92,7 +92,7 @@ def test_clump(mock_study_locus: StudyLocus) -> None:
                     "GCST005650_1",
                     1.0,
                     -17,
-                    [{"variantId": "T1"}, {"variantId": "L2"}],
+                    [{"tagVariantId": "T1"}, {"tagVariantId": "L2"}],
                     True,
                 ),
                 (
@@ -103,9 +103,9 @@ def test_clump(mock_study_locus: StudyLocus) -> None:
                     4.0,
                     -18,
                     [
-                        {"variantId": "T2"},
-                        {"variantId": "T3"},
-                        {"variantId": "L1"},
+                        {"tagVariantId": "T2"},
+                        {"tagVariantId": "T3"},
+                        {"tagVariantId": "L1"},
                     ],
                     False,
                 ),
@@ -117,9 +117,9 @@ def test_clump(mock_study_locus: StudyLocus) -> None:
                     4.0,
                     -18,
                     [
-                        {"variantId": "L3"},
-                        {"variantId": "T4"},
-                        {"variantId": "L5"},
+                        {"tagVariantId": "L3"},
+                        {"tagVariantId": "T4"},
+                        {"tagVariantId": "L5"},
                     ],
                     False,
                 ),
@@ -159,11 +159,11 @@ def test_is_lead_linked(
             t.StructField("pValueMantissa", t.FloatType(), True),
             t.StructField("pValueExponent", t.IntegerType(), True),
             t.StructField(
-                "locus",
+                "ldSet",
                 t.ArrayType(
                     t.StructType(
                         [
-                            t.StructField("variantId", t.StringType(), True),
+                            t.StructField("tagVariantId", t.StringType(), True),
                         ]
                     )
                 ),
@@ -184,7 +184,7 @@ def test_is_lead_linked(
                 f.col("variantId"),
                 f.col("pValueExponent"),
                 f.col("pValueMantissa"),
-                f.col("locus"),
+                f.col("ldSet"),
             ),
         )
         .orderBy("studyLocusId")

--- a/tests/method/test_clump.py
+++ b/tests/method/test_clump.py
@@ -32,7 +32,7 @@ def test_clump(mock_study_locus: StudyLocus) -> None:
                     "GCST005650_1",
                     1.0,
                     -17,
-                    [{"tagVariantId": "T1"}, {"tagVariantId": "L2"}],
+                    [{"variantId": "T1"}, {"variantId": "L2"}],
                     None,
                 ),
                 (
@@ -43,9 +43,9 @@ def test_clump(mock_study_locus: StudyLocus) -> None:
                     4.0,
                     -18,
                     [
-                        {"tagVariantId": "T2"},
-                        {"tagVariantId": "T3"},
-                        {"tagVariantId": "L1"},
+                        {"variantId": "T2"},
+                        {"variantId": "T3"},
+                        {"variantId": "L1"},
                     ],
                     None,
                 ),
@@ -57,9 +57,9 @@ def test_clump(mock_study_locus: StudyLocus) -> None:
                     4.0,
                     -18,
                     [
-                        {"tagVariantId": "L3"},
-                        {"tagVariantId": "T4"},
-                        {"tagVariantId": "L5"},
+                        {"variantId": "L3"},
+                        {"variantId": "T4"},
+                        {"variantId": "L5"},
                     ],
                     None,
                 ),
@@ -92,7 +92,7 @@ def test_clump(mock_study_locus: StudyLocus) -> None:
                     "GCST005650_1",
                     1.0,
                     -17,
-                    [{"tagVariantId": "T1"}, {"tagVariantId": "L2"}],
+                    [{"variantId": "T1"}, {"variantId": "L2"}],
                     True,
                 ),
                 (
@@ -103,9 +103,9 @@ def test_clump(mock_study_locus: StudyLocus) -> None:
                     4.0,
                     -18,
                     [
-                        {"tagVariantId": "T2"},
-                        {"tagVariantId": "T3"},
-                        {"tagVariantId": "L1"},
+                        {"variantId": "T2"},
+                        {"variantId": "T3"},
+                        {"variantId": "L1"},
                     ],
                     False,
                 ),
@@ -117,9 +117,9 @@ def test_clump(mock_study_locus: StudyLocus) -> None:
                     4.0,
                     -18,
                     [
-                        {"tagVariantId": "L3"},
-                        {"tagVariantId": "T4"},
-                        {"tagVariantId": "L5"},
+                        {"variantId": "L3"},
+                        {"variantId": "T4"},
+                        {"variantId": "L5"},
                     ],
                     False,
                 ),
@@ -163,7 +163,7 @@ def test_is_lead_linked(
                 t.ArrayType(
                     t.StructType(
                         [
-                            t.StructField("tagVariantId", t.StringType(), True),
+                            t.StructField("variantId", t.StringType(), True),
                         ]
                     )
                 ),

--- a/tests/method/test_pics.py
+++ b/tests/method/test_pics.py
@@ -101,15 +101,17 @@ def test__finemap() -> None:
         {
             "variantId": "var1",
             "r2Overall": 0.8,
-            "tagPValue": 1e-08,
-            "tagStandardError": 0.8294246485510745,
+            "pValueExponent": -8,
+            "pValueMantissa": 1.0,
+            "standardError": 0.8294246485510745,
             "posteriorProbability": 7.068873779583866e-134,
         },
         {
             "variantId": "var2",
             "r2Overall": 1,
-            "tagPValue": 1e-10,
-            "tagStandardError": 0.9977000638225533,
+            "pValueExponent": -10,
+            "pValueMantissa": 1.0,
+            "standardError": 0.9977000638225533,
             "posteriorProbability": 1.0,
         },
     ]


### PR DESCRIPTION
 ```      
        "name": "is95CredibleSet",
        "name": "is99CredibleSet",
        "name": "logABF",
        "name": "posteriorProbability",
        "name": "variantId",
        "name": "pValueMantissa",
        "name": "pValueExponent",
        "name": "pValueMantissaConditioned",
        "name": "pValueExponentConditioned",
        "name": "beta",
        "name": "standardError",
        "name": "betaConditioned",
        "name": "standardErrorConditioned",
        "name": "r2Overall",
  ```