### PR TITLE
feat: flexible window set up for locus collection

### DIFF
--- a/src/otg/dataset/summary_statistics.py
+++ b/src/otg/dataset/summary_statistics.py
@@ -79,7 +79,7 @@ class SummaryStatistics(Dataset):
                 window_length=distance,
                 p_value_significance=gwas_significance,
                 p_value_baseline=baseline_significance,
-                locus_window_lenght=locus_collect_distance,
+                locus_window_length=locus_collect_distance,
             )
         else:
             clumped_df = WindowBasedClumping.clump(

--- a/src/otg/dataset/summary_statistics.py
+++ b/src/otg/dataset/summary_statistics.py
@@ -57,6 +57,7 @@ class SummaryStatistics(Dataset):
         gwas_significance: float = 5e-8,
         with_locus: bool = False,
         baseline_significance: float = 0.05,
+        locus_collect_distance: int | None = None,
     ) -> StudyLocus:
         """Generate study-locus from summary statistics by distance based clumping + collect locus.
 
@@ -64,10 +65,13 @@ class SummaryStatistics(Dataset):
             distance (int): Distance in base pairs to be used for clumping.
             gwas_significance (float, optional): GWAS significance threshold. Defaults to 5e-8.
             baseline_significance (float, optional): Baseline significance threshold for inclusion in the locus. Defaults to 0.05.
+            locus_collect_distance (int, optional): The distance to collect locus around semi-indices.
 
         Returns:
             StudyLocus: Clumped study-locus containing variants based on window.
         """
+        if locus_collect_distance is None:
+            locus_collect_distance = distance
         # Based on if we want to get the locus different clumping function is called:
         if with_locus:
             clumped_df = WindowBasedClumping.clump_with_locus(
@@ -75,6 +79,7 @@ class SummaryStatistics(Dataset):
                 window_length=distance,
                 p_value_significance=gwas_significance,
                 p_value_baseline=baseline_significance,
+                locus_window_lenght=locus_collect_distance,
             )
         else:
             clumped_df = WindowBasedClumping.clump(

--- a/src/otg/dataset/summary_statistics.py
+++ b/src/otg/dataset/summary_statistics.py
@@ -65,7 +65,7 @@ class SummaryStatistics(Dataset):
             distance (int): Distance in base pairs to be used for clumping.
             gwas_significance (float, optional): GWAS significance threshold. Defaults to 5e-8.
             baseline_significance (float, optional): Baseline significance threshold for inclusion in the locus. Defaults to 0.05.
-            locus_collect_distance (int, optional): The distance to collect locus around semi-indices.
+            locus_collect_distance (int, optional): The distance to collect locus around semi-indices. If not provided, defaults to `distance`.
 
         Returns:
             StudyLocus: Clumped study-locus containing variants based on window.

--- a/src/otg/method/window_based_clumping.py
+++ b/src/otg/method/window_based_clumping.py
@@ -250,7 +250,7 @@ class WindowBasedClumping:
         window_length: int,
         p_value_significance: float = 5e-8,
         p_value_baseline: float = 0.05,
-        locus_window_lenght: int | None = None,
+        locus_window_length: int | None = None,
     ) -> StudyLocus:
         """Clump significant associations while collecting locus around them.
 
@@ -259,14 +259,14 @@ class WindowBasedClumping:
             window_length (int): Window size in  bp, used for distance based clumping and collecting locus
             p_value_significance (float, optional): GWAS significance threshold used to filter peaks. Defaults to 5e-8.
             p_value_baseline (float, optional): Least significant threshold. Below this, all snps are dropped. Defaults to 0.05.
-            locus_window_lenght (int, optional): The distance for collecting locus around the semi indices.
+            locus_window_length (int, optional): The distance for collecting locus around the semi indices.
 
         Returns:
             StudyLocus: StudyLocus after clumping with information about the `locus`
         """
         # If no locus window provided, using the same value:
-        if locus_window_lenght is None:
-            locus_window_lenght = window_length
+        if locus_window_length is None:
+            locus_window_length = window_length
 
         # Exclude problematic regions from clumping:
         filtered_summary_stats = reduce(
@@ -303,11 +303,11 @@ class WindowBasedClumping:
                     & (f.col("sumstat.tag_chromosome") == f.col("clumped.chromosome"))
                     & (
                         f.col("sumstat.tag_position")
-                        >= (f.col("clumped.position") - locus_window_lenght)
+                        >= (f.col("clumped.position") - locus_window_length)
                     )
                     & (
                         f.col("sumstat.tag_position")
-                        <= (f.col("clumped.position") + locus_window_lenght)
+                        <= (f.col("clumped.position") + locus_window_length)
                     )
                 ],
                 how="right",

--- a/src/otg/method/window_based_clumping.py
+++ b/src/otg/method/window_based_clumping.py
@@ -239,6 +239,11 @@ class WindowBasedClumping:
                     "studyLocusId",
                     StudyLocus.assign_study_locus_id("studyId", "variantId"),
                 )
+                # Adding QC column:
+                .withColumn(
+                    "qualityControls",
+                    f.array(),
+                )
             ),
             _schema=StudyLocus.get_schema(),
         )
@@ -327,7 +332,6 @@ class WindowBasedClumping:
             .groupby(*columns, "studyLocusId")
             .agg(f.collect_list(f.col("locus")).alias("locus"))
         )
-        study_locus_df.show(1, False, True)
 
         return StudyLocus(
             _df=study_locus_df,

--- a/src/otg/method/window_based_clumping.py
+++ b/src/otg/method/window_based_clumping.py
@@ -256,7 +256,7 @@ class WindowBasedClumping:
 
         Args:
             summary_stats (SummaryStatistics): Input summary statistics dataset
-            window_length (int): Window size in  bp, used for distance based clumping and collecting locus
+            window_length (int): Window size in  bp, used for distance based clumping.
             p_value_significance (float, optional): GWAS significance threshold used to filter peaks. Defaults to 5e-8.
             p_value_baseline (float, optional): Least significant threshold. Below this, all snps are dropped. Defaults to 0.05.
             locus_window_length (int, optional): The distance for collecting locus around the semi indices.

--- a/src/otg/method/window_based_clumping.py
+++ b/src/otg/method/window_based_clumping.py
@@ -250,6 +250,7 @@ class WindowBasedClumping:
         window_length: int,
         p_value_significance: float = 5e-8,
         p_value_baseline: float = 0.05,
+        locus_window_lenght: int | None = None,
     ) -> StudyLocus:
         """Clump significant associations while collecting locus around them.
 
@@ -258,10 +259,15 @@ class WindowBasedClumping:
             window_length (int): Window size in  bp, used for distance based clumping and collecting locus
             p_value_significance (float, optional): GWAS significance threshold used to filter peaks. Defaults to 5e-8.
             p_value_baseline (float, optional): Least significant threshold. Below this, all snps are dropped. Defaults to 0.05.
+            locus_window_lenght (int, optional): The distance for collecting locus around the semi indices.
 
         Returns:
             StudyLocus: StudyLocus after clumping with information about the `locus`
         """
+        # If no locus window provided, using the same value:
+        if locus_window_lenght is None:
+            locus_window_lenght = window_length
+
         # Exclude problematic regions from clumping:
         filtered_summary_stats = reduce(
             lambda df, region: df.exclude_region(region),
@@ -297,11 +303,11 @@ class WindowBasedClumping:
                     & (f.col("sumstat.tag_chromosome") == f.col("clumped.chromosome"))
                     & (
                         f.col("sumstat.tag_position")
-                        >= f.col("clumped.position") - window_length
+                        >= (f.col("clumped.position") - locus_window_lenght)
                     )
                     & (
                         f.col("sumstat.tag_position")
-                        <= f.col("clumped.position") + window_length
+                        <= (f.col("clumped.position") + locus_window_lenght)
                     )
                 ],
                 how="right",


### PR DESCRIPTION
Ocassionally we want to apply a different threshold to do window based clumping and to collect locus around a semi index. This was not possible before. Now the two distances are de-coupled.