### PR TITLE
Some studies just don't have population data causing LD annotation fail

### DIFF
--- a/src/otg/dataset/study_locus.py
+++ b/src/otg/dataset/study_locus.py
@@ -47,6 +47,7 @@ class StudyLocusQualityCheck(Enum):
     AMBIGUOUS_STUDY = "Association with ambiguous study"
     UNRESOLVED_LD = "Variant not found in LD reference"
     LD_CLUMPED = "Explained by a more significant variant in high LD (clumped)"
+    NO_POPULATION = "Study does not have population annotation to resolve LD"
 
 
 class CredibleInterval(Enum):
@@ -426,6 +427,26 @@ class StudyLocus(Dataset):
                 f.col("qualityControls"),
                 f.col("ldSet").isNull(),
                 StudyLocusQualityCheck.UNRESOLVED_LD,
+            ),
+        )
+        return self
+
+    def _qc_no_population(self: StudyLocus) -> StudyLocus:
+        """Flag associations where the study doesn't have population information to resolve LD.
+
+        Returns:
+            StudyLocusGWASCatalog | StudyLocus: Updated study locus.
+        """
+        # If the tested column is not present, return self unchanged:
+        if "ldPopulationStructure" not in self.df.columns:
+            return self
+
+        self.df = self.df.withColumn(
+            "qualityControls",
+            self._update_quality_flag(
+                f.col("qualityControls"),
+                f.col("ldPopulationStructure").isNull(),
+                StudyLocusQualityCheck.NO_POPULATION,
             ),
         )
         return self

--- a/src/otg/method/pics.py
+++ b/src/otg/method/pics.py
@@ -8,7 +8,6 @@ import pyspark.sql.functions as f
 import pyspark.sql.types as t
 from scipy.stats import norm
 
-from otg.common.utils import split_pvalue
 from otg.dataset.study_locus import StudyLocus
 
 if TYPE_CHECKING:
@@ -128,6 +127,11 @@ class PICS:
             >>> PICS._finemap(ld_set_with_no_r2, lead_neglog_p=10.0, k=6.4)
             [{'variantId': 'var1', 'r2Overall': None}, {'variantId': 'var2', 'r2Overall': None}]
         """
+        if ld_set is None:
+            return None
+        elif not ld_set:
+            return []
+
         tmp_credible_set = []
         new_credible_set = []
         # First iteration: calculation of mu, standard deviation, and the relative posterior probability
@@ -143,6 +147,7 @@ class PICS:
                 # If PICS cannot be calculated, we'll return the original credible set
                 new_credible_set.append(tag_dict)
                 continue
+
             pics_snp_mu = PICS._pics_mu(lead_neglog_p, tag_dict["r2Overall"])
             pics_snp_std = PICS._pics_standard_deviation(
                 lead_neglog_p, tag_dict["r2Overall"], k
@@ -152,9 +157,6 @@ class PICS:
                 posterior_probability = PICS._pics_relative_posterior_probability(
                     lead_neglog_p, pics_snp_mu, pics_snp_std
                 )
-                mantissa, exponent = split_pvalue(10**-pics_snp_mu)
-                tag_dict["pValueMantissa"] = mantissa
-                tag_dict["pValueExponent"] = exponent
                 tag_dict["standardError"] = 10**-pics_snp_std
                 tag_dict["relativePosteriorProbability"] = posterior_probability
 

--- a/src/otg/method/pics.py
+++ b/src/otg/method/pics.py
@@ -116,7 +116,7 @@ class PICS:
             ...     Row(variantId="var2", r2Overall=1),
             ... ]
             >>> PICS._finemap(ld_set, lead_neglog_p=10.0, k=6.4)
-            [{'variantId': 'var1', 'r2Overall': 0.8, 'pValueMantissa': 1.0, 'pValueExponent': -8, 'standardError': 0.07420896512708416, 'posteriorProbability': 0.07116959886882368}, {'variantId': 'var2', 'r2Overall': 1, 'pValueMantissa': 1.0, 'pValueExponent': -10, 'standardError': 0.9977000638225533, 'posteriorProbability': 0.9288304011311763}]
+            [{'variantId': 'var1', 'r2Overall': 0.8, 'standardError': 0.07420896512708416, 'posteriorProbability': 0.07116959886882368}, {'variantId': 'var2', 'r2Overall': 1, 'standardError': 0.9977000638225533, 'posteriorProbability': 0.9288304011311763}]
             >>> empty_ld_set = []
             >>> PICS._finemap(empty_ld_set, lead_neglog_p=10.0, k=6.4)
             []

--- a/tests/method/test_pics.py
+++ b/tests/method/test_pics.py
@@ -50,16 +50,12 @@ def test__finemap_udf() -> None:
         {
             "variantId": "var1",
             "r2Overall": 0.8,
-            "pValueMantissa": 1.0,
-            "pValueExponent": -8,
             "standardError": 0.07420896512708416,
             "posteriorProbability": 0.07116959886882368,
         },
         {
             "variantId": "var2",
             "r2Overall": 1,
-            "pValueMantissa": 1.0,
-            "pValueExponent": -10,
             "standardError": 0.9977000638225533,
             "posteriorProbability": 0.9288304011311763,
         },


### PR DESCRIPTION
I'm not 100% sure this is the right thing to do... The LD set certainly can be resolved, but the subsequent r2Overall calculation fails. Adding the condition nullifies the LD set, but then we need to add an other QC metric to flag these special cases.

```python
(
    study_index.df
    .filter(f.col('ldPopulationStructure').isNull())
    .select('studyId', 'ldPopulationStructure')
    .show(20)
)
```

Out of 87,996 studies 12:
```
+------------+---------------------+
|     studyId|ldPopulationStructure|
+------------+---------------------+
|  GCST000218|                 null|
|GCST90093226|                 null|
|GCST90093235|                 null|
|  GCST000870|                 null|
|GCST90093223|                 null|
|GCST90102942|                 null|
|GCST90093229|                 null|
|GCST90093238|                 null|
|GCST90093232|                 null|
|GCST90093220|                 null|
|GCST90093217|                 null|
|  GCST000768|                 null|
+------------+---------------------+
```