### PR TITLE
issue with docs images

### DIFF
--- a/docs/python_api/datasource/finngen/_finngen.md
+++ b/docs/python_api/datasource/finngen/_finngen.md
@@ -3,7 +3,7 @@ title: FinnGen
 ---
 
 <p align="center">
-  <img width="300" height="200" src="/assets/imgs/finngen.svg">
+  <img width="300" height="200" src="../../../../assets/imgs/finngen.svg">
 </p>
 <style>
   .md-typeset h1,

--- a/docs/python_api/datasource/gnomad/_gnomad.md
+++ b/docs/python_api/datasource/gnomad/_gnomad.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img width="300" height="200" src="/assets/imgs/gnomad.svg">
+  <img width="300" height="200" src="../../../../assets/imgs/gnomad.svg">
 </p>
 <style>
   .md-typeset h1,

--- a/docs/python_api/datasource/gwas_catalog/_gwas_catalog.md
+++ b/docs/python_api/datasource/gwas_catalog/_gwas_catalog.md
@@ -1,5 +1,5 @@
 <div align="center">
-  <img width="100" height="100" src="/assets/imgs/GWAS_Catalog_circle_178x178.png">
+  <img width="100" height="100" src="../../../../assets/imgs/GWAS_Catalog_circle_178x178.png">
   <h1>GWAS Catalog</h1>
 </div>
 

--- a/docs/python_api/datasource/open_targets/_open_targets.md
+++ b/docs/python_api/datasource/open_targets/_open_targets.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img width="400" height="200" src="/assets/imgs/open_targets_platform.svg">
+  <img width="400" height="200" src="../../../../assets/imgs/open_targets_platform.svg">
 </p>
 <style>
   .md-typeset h1,

--- a/docs/python_api/datasource/ukbiobank/_ukbiobank.md
+++ b/docs/python_api/datasource/ukbiobank/_ukbiobank.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img width="400" height="200" src="/assets/imgs/UK_biobank_logo.png">
+  <img width="400" height="200" src="../../../../assets/imgs/UK_biobank_logo.png">
 </p>
 <style>
   .md-typeset h1,


### PR DESCRIPTION
As described in the [mkdocs documentation](https://www.mkdocs.org/user-guide/writing-your-docs/#linking-to-pages), while absolute paths might work in local deployment they are not supported and didn't work in the deployed docs.

This PR fixes the issue