### PR TITLE
Add missing columns in gene index

### DIFF
--- a/config/datasets/gcp.yaml
+++ b/config/datasets/gcp.yaml
@@ -27,7 +27,7 @@ ld_index_raw_template: gs://gcp-public-data--gnomad/release/2.1.1/ld/gnomad.geno
 ld_matrix_template: gs://gcp-public-data--gnomad/release/2.1.1/ld/gnomad.genomes.r2.1.1.{POP}.common.adj.ld.bm
 
 # Output datasets
-gene_index: ${datasets.outputs}/gene_index/gene_index
+gene_index: ${datasets.outputs}/gene_index
 variant_annotation: ${datasets.outputs}/variant_annotation
 variant_index: ${datasets.outputs}/variant_index
 study_locus: ${datasets.outputs}/study_locus

--- a/src/otg/assets/schemas/gene_index.json
+++ b/src/otg/assets/schemas/gene_index.json
@@ -32,30 +32,14 @@
       "metadata": {}
     },
     {
+      "metadata": {},
       "name": "obsoleteSymbols",
-      "type": {
-        "type": "array",
-        "elementType": {
-          "type": "struct",
-          "fields": [
-            {
-              "name": "label",
-              "type": "string",
-              "nullable": true,
-              "metadata": {}
-            },
-            {
-              "name": "source",
-              "type": "string",
-              "nullable": true,
-              "metadata": {}
-            }
-          ]
-        },
-        "containsNull": true
-      },
       "nullable": true,
-      "metadata": {}
+      "type": {
+        "containsNull": true,
+        "elementType": "string",
+        "type": "array"
+      }
     },
     {
       "name": "tss",

--- a/src/otg/dataset/gene_index.py
+++ b/src/otg/dataset/gene_index.py
@@ -64,7 +64,7 @@ class GeneIndex(Dataset):
         """
         return self.df.select(
             f.explode(
-                f.array_union(f.array("approvedSymbol"), f.col("obsoleteSymbols.label"))
+                f.array_union(f.array("approvedSymbol"), f.col("obsoleteSymbols"))
             ).alias("geneSymbol"),
             "*",
         )

--- a/src/otg/datasource/open_targets/target.py
+++ b/src/otg/datasource/open_targets/target.py
@@ -52,6 +52,7 @@ class OpenTargetsTarget:
                 "approvedSymbol",
                 "approvedName",
                 "biotype",
+                f.col("obsoleteSymbols.label").alias("obsoleteSymbols"),
                 f.coalesce(f.col("genomicLocation.chromosome"), f.lit("unknown")).alias(
                     "chromosome"
                 ),

--- a/src/otg/datasource/open_targets/target.py
+++ b/src/otg/datasource/open_targets/target.py
@@ -49,6 +49,9 @@ class OpenTargetsTarget:
         return GeneIndex(
             _df=target_index.select(
                 f.coalesce(f.col("id"), f.lit("unknown")).alias("geneId"),
+                "approvedSymbol",
+                "approvedName",
+                "biotype",
                 f.coalesce(f.col("genomicLocation.chromosome"), f.lit("unknown")).alias(
                     "chromosome"
                 ),


### PR DESCRIPTION
In the process of running V2G I ran into minor issues with the gene index.
This PR contains:
- Fix typo in the gene index output path
- Addition of missing columns of the target dataset that are used later in the project:
    -  approvedSymbol
    - approvedName
    - biotype - used in V2G
    - obsoleteSymbols
- with `obsoleteSymbols`, I propose a simplification of the schema. Impact is small. As a counterargument, we might not want to deviate from the target's original schema. Let me know your comments
    - In the target we have an array of structs with `label` and `source`
    - In my changes I propose to extract only the labels, so that we simply operate with an array of strings  

Output is herer `gs://genetics_etl_python_playground/output/python_etl/parquet/XX.XX/gene_index`