### PR TITLE
fix(docs): schemas path for gene and study index

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -28,6 +28,6 @@ hide:
 
 Ingestion and analysis of genetic and functional genomic data for the identification and prioritisation of drug targets.
 
-This project is still in experimental phase. Please refer to the [roadmap section](./roadmap/) for more information.
+This project is still in experimental phase. Please refer to the [roadmap section](roadmap.md) for more information.
 
-For information on how to contribute to the project see the [contributing section](./contributing).
+For information on how to contribute to the project see the [contributing section](./contributing/_contributing.md).

--- a/docs/python_api/dataset/gene_index.md
+++ b/docs/python_api/dataset/gene_index.md
@@ -2,7 +2,7 @@
 
 ## Schema
 
---8<-- "assets/schemas/targets.md"
+--8<-- "assets/schemas/gene_index.md"
 
 ## Class
 

--- a/docs/python_api/dataset/study_index.md
+++ b/docs/python_api/dataset/study_index.md
@@ -2,7 +2,7 @@
 
 ## Schema
 
---8<-- "assets/schemas/studies.md"
+--8<-- "assets/schemas/study_index.md"
 
 ## Class
 

--- a/src/scripts/schemadocs.py
+++ b/src/scripts/schemadocs.py
@@ -62,4 +62,4 @@ def on_pre_build(config: MkdocsConfig, **kwargs) -> None:
         assets_dir=assets_dir,
         schema_dir="src/otg/assets/schemas",
     )
-    print(f"Schema assests generated for {config['site_name']}")
+    print(f"Schema assets generated for {config['site_name']}")


### PR DESCRIPTION
Schemas for Gene and Study index were pointing to an obsolete filename.