### PR TITLE
Refactor step configuration

### DIFF
--- a/config/step/my_colocalisation.yaml
+++ b/config/step/my_colocalisation.yaml
@@ -1,2 +1,3 @@
+_target_: otg.colocalisation.ColocalisationStep
 study_locus_path: ${datasets.study_locus}
 coloc_path: ${datasets.colocalisation}

--- a/config/step/my_colocalisation.yaml
+++ b/config/step/my_colocalisation.yaml
@@ -1,6 +1,2 @@
-# Default config
-defaults:
-  - colocalisation
-# Additional config
 study_locus_path: ${datasets.study_locus}
 coloc_path: ${datasets.colocalisation}

--- a/config/step/my_finngen.yaml
+++ b/config/step/my_finngen.yaml
@@ -1,7 +1,3 @@
-# Default config
-defaults:
-  - finngen
-# Additional config
 finngen_phenotype_table_url: ${datasets.finngen_phenotype_table_url}
 finngen_release_prefix: ${datasets.finngen_release_prefix}
 finngen_sumstat_url_prefix: ${datasets.finngen_sumstat_url_prefix}

--- a/config/step/my_finngen.yaml
+++ b/config/step/my_finngen.yaml
@@ -1,3 +1,4 @@
+_target_: otg.finngen.FinnGenStep
 finngen_phenotype_table_url: ${datasets.finngen_phenotype_table_url}
 finngen_release_prefix: ${datasets.finngen_release_prefix}
 finngen_sumstat_url_prefix: ${datasets.finngen_sumstat_url_prefix}

--- a/config/step/my_gene_index.yaml
+++ b/config/step/my_gene_index.yaml
@@ -1,6 +1,2 @@
-# Default config
-defaults:
-  - gene_index
-# Additional config
 target_path: ${datasets.target_index}
 gene_index_path: ${datasets.gene_index}

--- a/config/step/my_gene_index.yaml
+++ b/config/step/my_gene_index.yaml
@@ -1,2 +1,3 @@
+_target_: otg.gene_index.GeneIndexStep
 target_path: ${datasets.target_index}
 gene_index_path: ${datasets.gene_index}

--- a/config/step/my_gwas_catalog.yaml
+++ b/config/step/my_gwas_catalog.yaml
@@ -1,3 +1,4 @@
+_target_: otg.gwas_catalog.GWASCatalogStep
 catalog_studies_file: ${datasets.catalog_studies}
 catalog_ancestry_file: ${datasets.catalog_ancestries}
 catalog_associations_file: ${datasets.catalog_associations}

--- a/config/step/my_gwas_catalog.yaml
+++ b/config/step/my_gwas_catalog.yaml
@@ -1,7 +1,3 @@
-# Default config
-defaults:
-  - gwas_catalog
-# Additional config
 catalog_studies_file: ${datasets.catalog_studies}
 catalog_ancestry_file: ${datasets.catalog_ancestries}
 catalog_associations_file: ${datasets.catalog_associations}

--- a/config/step/my_ld_index.yaml
+++ b/config/step/my_ld_index.yaml
@@ -1,3 +1,4 @@
+_target_: otg.ld_index.LDIndexStep
 grch37_to_grch38_chain_path: ${datasets.chain_hail_37_38}
 ld_index_raw_template: ${datasets.ld_index_raw_template}
 ld_index_out: ${datasets.ld_index}

--- a/config/step/my_ld_index.yaml
+++ b/config/step/my_ld_index.yaml
@@ -1,7 +1,3 @@
-# Default config
-defaults:
-  - ld_index
-# Additional config
 grch37_to_grch38_chain_path: ${datasets.chain_hail_37_38}
 ld_index_raw_template: ${datasets.ld_index_raw_template}
 ld_index_out: ${datasets.ld_index}

--- a/config/step/my_study_locus_overlap.yaml
+++ b/config/step/my_study_locus_overlap.yaml
@@ -1,7 +1,3 @@
-# Default config
-defaults:
-  - study_locus_overlap
-# Additional config
 study_locus_path: ${datasets.outputs}/catalog_study_locus
 study_index_path: ${datasets.outputs}/catalog_study_index
 overlaps_index_out: ${datasets.outputs}/study_locus_overlap

--- a/config/step/my_study_locus_overlap.yaml
+++ b/config/step/my_study_locus_overlap.yaml
@@ -1,3 +1,4 @@
+_target_: otg.overlaps.OverlapsIndexStep
 study_locus_path: ${datasets.outputs}/catalog_study_locus
 study_index_path: ${datasets.outputs}/catalog_study_index
 overlaps_index_out: ${datasets.outputs}/study_locus_overlap

--- a/config/step/my_ukbiobank.yaml
+++ b/config/step/my_ukbiobank.yaml
@@ -1,6 +1,2 @@
-# Default config
-defaults:
-  - ukbiobank
-# Additional config
 ukbiobank_manifest: ${datasets.ukbiobank_manifest}
 ukbiobank_study_index_out: ${datasets.ukbiobank_study_index}

--- a/config/step/my_ukbiobank.yaml
+++ b/config/step/my_ukbiobank.yaml
@@ -1,2 +1,3 @@
+_target_: otg.ukbiobank.UKBiobankStep
 ukbiobank_manifest: ${datasets.ukbiobank_manifest}
 ukbiobank_study_index_out: ${datasets.ukbiobank_study_index}

--- a/config/step/my_v2g.yaml
+++ b/config/step/my_v2g.yaml
@@ -1,7 +1,3 @@
-# Default config
-defaults:
-  - v2g
-# Additional config
 variant_index_path: ${datasets.variant_index}
 variant_annotation_path: ${datasets.variant_annotation}
 gene_index_path: ${datasets.gene_index}

--- a/config/step/my_v2g.yaml
+++ b/config/step/my_v2g.yaml
@@ -1,3 +1,4 @@
+_target_: otg.v2g.V2GStep
 variant_index_path: ${datasets.variant_index}
 variant_annotation_path: ${datasets.variant_annotation}
 gene_index_path: ${datasets.gene_index}

--- a/config/step/my_variant_annotation.yaml
+++ b/config/step/my_variant_annotation.yaml
@@ -1,3 +1,4 @@
+_target_: otg.variant_annotation.VariantAnnotationStep
 gnomad_genomes: ${datasets.gnomad_genomes}
 chain_38_to_37: ${datasets.chain_hail_38_37}
 variant_annotation_path: ${datasets.variant_annotation}

--- a/config/step/my_variant_annotation.yaml
+++ b/config/step/my_variant_annotation.yaml
@@ -1,7 +1,3 @@
-# Default config
-defaults:
-  - variant_annotation
-# Additional config
 gnomad_genomes: ${datasets.gnomad_genomes}
 chain_38_to_37: ${datasets.chain_hail_38_37}
 variant_annotation_path: ${datasets.variant_annotation}

--- a/config/step/my_variant_index.yaml
+++ b/config/step/my_variant_index.yaml
@@ -1,3 +1,4 @@
+_target_: otg.variant_index.VariantIndexStep
 variant_annotation_path: ${datasets.variant_annotation}
 study_locus_path: ${datasets.study_locus}
 variant_index_path: ${datasets.variant_index}

--- a/config/step/my_variant_index.yaml
+++ b/config/step/my_variant_index.yaml
@@ -1,7 +1,3 @@
-# Default config
-defaults:
-  - variant_index
-# Additional config
 variant_annotation_path: ${datasets.variant_annotation}
 study_locus_path: ${datasets.study_locus}
 variant_index_path: ${datasets.variant_index}

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -58,14 +58,13 @@ For more details on each of these steps, see the sections below.
 * If during development you had a question which wasn't covered in the documentation, and someone explained it to you, add it to the documentation. The same applies if you encountered any instructions in the documentation which were obsolete or incorrect.
 * Documentation autogeneration expressions start with `:::`. They will automatically generate sections of the documentation based on class and method docstrings. Be sure to update them for:
   + Dataset definitions in `docs/reference/dataset` (example: `docs/reference/dataset/study_index/study_index_finngen.md`)
-  + Step definitions in `docs/reference/step` (example: `docs/reference/step/finngen.md`)
+  + Step definition in `docs/reference/step` (example: `docs/reference/step/finngen.md`)
 
 ### Configuration
 * Input and output paths in `config/datasets/gcp.yaml`
 * Step configuration in `config/step/my_STEP.yaml` (example: `config/step/my_finngen.yaml`)
 
 ### Classes
-* Step configuration class in `src/org/config.py` (example: `FinnGenStepConfig` class in that module)
 * Dataset class in `src/org/dataset/` (example: `src/otg/dataset/study_index.py` → `StudyIndexFinnGen`)
 * Step main running class in `src/org/STEP.py` (example: `src/org/finngen.py`)
 

--- a/docs/python_api/step/colocalisation.md
+++ b/docs/python_api/step/colocalisation.md
@@ -1,4 +1,3 @@
 # Colocalisation
 
 ::: otg.colocalisation.ColocalisationStep
-::: otg.config.ColocalisationStepConfig

--- a/docs/python_api/step/finngen.md
+++ b/docs/python_api/step/finngen.md
@@ -1,4 +1,3 @@
 # FinnGen
 
 ::: otg.finngen.FinnGenStep
-::: otg.config.FinnGenStepConfig

--- a/docs/python_api/step/gene_index.md
+++ b/docs/python_api/step/gene_index.md
@@ -1,4 +1,3 @@
 # Gene index
 
 ::: otg.gene_index.GeneIndexStep
-::: otg.config.GeneIndexStepConfig

--- a/docs/python_api/step/gwas_catalog.md
+++ b/docs/python_api/step/gwas_catalog.md
@@ -1,4 +1,3 @@
 # GWAS Catalog
 
 ::: otg.gwas_catalog.GWASCatalogStep
-::: otg.config.GWASCatalogStepConfig

--- a/docs/python_api/step/gwas_catalog_sumstat_preprocess.md
+++ b/docs/python_api/step/gwas_catalog_sumstat_preprocess.md
@@ -1,4 +1,3 @@
 # GWAS Catalog sumstat preprocess
 
 ::: otg.gwas_catalog_sumstat_preprocess.GWASCatalogSumstatsPreprocessStep
-::: otg.config.GWASCatalogSumstatsPreprocessConfig

--- a/docs/python_api/step/ld_index.md
+++ b/docs/python_api/step/ld_index.md
@@ -1,4 +1,3 @@
 # LD index
 
 ::: otg.ld_index.LDIndexStep
-::: otg.config.LDIndexStepConfig

--- a/docs/python_api/step/ukbiobank.md
+++ b/docs/python_api/step/ukbiobank.md
@@ -1,4 +1,3 @@
 # UKBiobank
 
 ::: otg.ukbiobank.UKBiobankStep
-::: otg.config.UKBiobankStepConfig

--- a/docs/python_api/step/variant_annotation_step.md
+++ b/docs/python_api/step/variant_annotation_step.md
@@ -1,4 +1,3 @@
 # Variant annotation
 
 ::: otg.variant_annotation.VariantAnnotationStep
-::: otg.config.VariantAnnotationStepConfig

--- a/docs/python_api/step/variant_index_step.md
+++ b/docs/python_api/step/variant_index_step.md
@@ -1,4 +1,3 @@
 # Variant index
 
 ::: otg.variant_index.VariantIndexStep
-::: otg.config.VariantIndexStepConfig

--- a/docs/python_api/step/variant_to_gene_step.md
+++ b/docs/python_api/step/variant_to_gene_step.md
@@ -1,4 +1,3 @@
 # V2G
 
 ::: otg.v2g.V2GStep
-::: otg.config.V2GStepConfig

--- a/src/otg/colocalisation.py
+++ b/src/otg/colocalisation.py
@@ -3,21 +3,36 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from omegaconf import MISSING
+
 from otg.common.session import Session
-from otg.config import ColocalisationStepConfig
 from otg.dataset.study_index import StudyIndex
 from otg.dataset.study_locus import CredibleInterval, StudyLocus
 from otg.method.colocalisation import Coloc, ECaviar
 
 
 @dataclass
-class ColocalisationStep(ColocalisationStepConfig):
+class ColocalisationStep:
     """Colocalisation step.
 
     This workflow runs colocalization analyses that assess the degree to which independent signals of the association share the same causal variant in a region of the genome, typically limited by linkage disequilibrium (LD).
+
+    Attributes:
+        study_locus_path (DictConfig): Input Study-locus path.
+        coloc_path (DictConfig): Output Colocalisation path.
+        priorc1 (float): Prior on variant being causal for trait 1.
+        priorc2 (float): Prior on variant being causal for trait 2.
+        priorc12 (float): Prior on variant being causal for traits 1 and 2.
     """
 
     session: Session = Session()
+
+    study_locus_path: str = MISSING
+    study_index_path: str = MISSING
+    coloc_path: str = MISSING
+    priorc1: float = 1e-4
+    priorc2: float = 1e-4
+    priorc12: float = 1e-5
 
     def run(self: ColocalisationStep) -> None:
         """Run colocalisation step."""

--- a/src/otg/config.py
+++ b/src/otg/config.py
@@ -33,41 +33,6 @@ class SessionConfig:
 
 
 @dataclass
-class LDIndexStepConfig:
-    """LD matrix step requirements.
-
-    Attributes:
-        ld_matrix_template (str): Template path for LD matrix from gnomAD.
-        ld_index_raw_template (str): Template path for the variant indices correspondance in the LD Matrix from gnomAD.
-        min_r2 (float): Minimum r2 to consider when considering variants within a window.
-        grch37_to_grch38_chain_path (str): Path to GRCh37 to GRCh38 chain file.
-        ld_populations (List[str]): List of population-specific LD matrices to process.
-        ld_index_out (str): Output LD index path.
-    """
-
-    _target_: str = "otg.ld_index.LDIndexStep"
-    ld_matrix_template: str = "gs://gcp-public-data--gnomad/release/2.1.1/ld/gnomad.genomes.r2.1.1.{POP}.common.adj.ld.bm"
-    ld_index_raw_template: str = "gs://gcp-public-data--gnomad/release/2.1.1/ld/gnomad.genomes.r2.1.1.{POP}.common.ld.variant_indices.ht"
-    min_r2: float = 0.5
-    grch37_to_grch38_chain_path: str = (
-        "gs://hail-common/references/grch37_to_grch38.over.chain.gz"
-    )
-    ld_populations: List[str] = field(
-        default_factory=lambda: [
-            "afr",  # African-American
-            "amr",  # American Admixed/Latino
-            "asj",  # Ashkenazi Jewish
-            "eas",  # East Asian
-            "fin",  # Finnish
-            "nfe",  # Non-Finnish European
-            "nwe",  # Northwestern European
-            "seu",  # Southeastern European
-        ]
-    )
-    ld_index_out: str = MISSING
-
-
-@dataclass
 class VariantIndexStepConfig:
     """Variant index step requirements.
 

--- a/src/otg/config.py
+++ b/src/otg/config.py
@@ -299,18 +299,3 @@ def register_configs() -> None:
     cs = ConfigStore.instance()
     cs.store(name="config", node=Config)
     cs.store(name="session_config", group="session", node=SessionConfig)
-    cs.store(name="gene_index", group="step", node=GeneIndexStepConfig)
-    cs.store(name="ld_index", group="step", node=LDIndexStepConfig)
-    cs.store(name="variant_index", group="step", node=VariantIndexStepConfig)
-    cs.store(name="variant_annotation", group="step", node=VariantAnnotationStepConfig)
-    cs.store(name="v2g", group="step", node=V2GStepConfig)
-    cs.store(name="colocalisation", group="step", node=ColocalisationStepConfig)
-    cs.store(name="gwas_catalog", group="step", node=GWASCatalogStepConfig)
-    cs.store(name="finngen", group="step", node=FinnGenStepConfig)
-    cs.store(name="ukbiobank", group="step", node=UKBiobankStepConfig)
-    cs.store(
-        name="gwas_catalog_sumstats_preprocess",
-        group="step",
-        node=GWASCatalogSumstatsPreprocessConfig,
-    )
-    cs.store(name="study_locus_overlap", group="step", node=StudyLocusOverlapStepConfig)

--- a/src/otg/config.py
+++ b/src/otg/config.py
@@ -237,28 +237,6 @@ class GWASCatalogSumstatsPreprocessConfig:
 
 
 @dataclass
-class FinnGenStepConfig:
-    """FinnGen study table ingestion step requirements.
-
-    Attributes:
-        finngen_phenotype_table_url (str): FinnGen API for fetching the list of studies.
-        finngen_release_prefix (str): Release prefix pattern.
-        finngen_sumstat_url_prefix (str): URL prefix for summary statistics location.
-        finngen_sumstat_url_suffix (str): URL prefix suffix for summary statistics location.
-        finngen_study_index_out (str): Output path for the FinnGen study index dataset.
-        finngen_summary_stats_out (str): Output path for the FinnGen summary statistics.
-    """
-
-    _target_: str = "otg.finngen.FinnGenStep"
-    finngen_phenotype_table_url: str = MISSING
-    finngen_release_prefix: str = MISSING
-    finngen_sumstat_url_prefix: str = MISSING
-    finngen_sumstat_url_suffix: str = MISSING
-    finngen_study_index_out: str = MISSING
-    finngen_summary_stats_out: str = MISSING
-
-
-@dataclass
 class UKBiobankStepConfig:
     """UKBiobank study table ingestion step requirements.
 

--- a/src/otg/config.py
+++ b/src/otg/config.py
@@ -48,37 +48,6 @@ class VariantIndexStepConfig:
     variant_index_path: str = MISSING
 
 
-@dataclass
-class VariantAnnotationStepConfig:
-    """Variant annotation step requirements.
-
-    Attributes:
-        gnomad_genomes (str): Path to gnomAD genomes hail table.
-        chain_38_to_37 (str): Path to GRCh38 to GRCh37 chain file.
-        variant_annotation_path (str): Output variant annotation path.
-        populations (List[str]): List of populations to include.
-    """
-
-    _target_: str = "otg.variant_annotation.VariantAnnotationStep"
-    gnomad_genomes: str = MISSING
-    chain_38_to_37: str = MISSING
-    variant_annotation_path: str = MISSING
-    populations: List[str] = field(
-        default_factory=lambda: [
-            "afr",  # African-American
-            "amr",  # American Admixed/Latino
-            "ami",  # Amish ancestry
-            "asj",  # Ashkenazi Jewish
-            "eas",  # East Asian
-            "fin",  # Finnish
-            "nfe",  # Non-Finnish European
-            "mid",  # Middle Eastern
-            "sas",  # South Asian
-            "oth",  # Other
-        ]
-    )
-
-
 # Register all configs
 def register_configs() -> None:
     """Register configs."""

--- a/src/otg/config.py
+++ b/src/otg/config.py
@@ -161,34 +161,6 @@ class V2GStepConfig:
 
 
 @dataclass
-class GWASCatalogStepConfig:
-    """GWAS Catalog step requirements.
-
-    Attributes:
-        catalog_studies_file (str): Raw GWAS catalog studies file.
-        catalog_ancestry_file (str): Ancestry annotations file from GWAS Catalog.
-        catalog_sumstats_lut (str): GWAS Catalog summary statistics lookup table.
-        catalog_associations_file (str): Raw GWAS catalog associations file.
-        variant_annotation_path (str): Input variant annotation path.
-        ld_populations (list): List of populations to include.
-        min_r2 (float): Minimum r2 to consider when considering variants within a window.
-        catalog_studies_out (str): Output GWAS catalog studies path.
-        catalog_associations_out (str): Output GWAS catalog associations path.
-    """
-
-    _target_: str = "otg.gwas_catalog.GWASCatalogStep"
-    catalog_studies_file: str = MISSING
-    catalog_ancestry_file: str = MISSING
-    catalog_sumstats_lut: str = MISSING
-    catalog_associations_file: str = MISSING
-    variant_annotation_path: str = MISSING
-    ld_index_path: str = MISSING
-    min_r2: float = 0.5
-    catalog_studies_out: str = MISSING
-    catalog_associations_out: str = MISSING
-
-
-@dataclass
 class StudyLocusOverlapStepConfig:
     """StudyLocus overlaps index step requirements.
 

--- a/src/otg/config.py
+++ b/src/otg/config.py
@@ -177,24 +177,6 @@ class StudyLocusOverlapStepConfig:
 
 
 @dataclass
-class GWASCatalogSumstatsPreprocessConfig:
-    """GWAS Catalog Sumstats Preprocessing step requirements.
-
-    Attributes:
-        raw_sumstats_path (str): Input raw GWAS Catalog summary statistics path.
-        out_sumstats_path (str): Output GWAS Catalog summary statistics path.
-        study_id (str): GWAS Catalog study identifier.
-    """
-
-    _target_: str = (
-        "otg.gwas_catalog_sumstat_preprocess.GWASCatalogSumstatsPreprocessStep"
-    )
-    raw_sumstats_path: str = MISSING
-    out_sumstats_path: str = MISSING
-    study_id: str = MISSING
-
-
-@dataclass
 class UKBiobankStepConfig:
     """UKBiobank study table ingestion step requirements.
 

--- a/src/otg/config.py
+++ b/src/otg/config.py
@@ -32,22 +32,6 @@ class SessionConfig:
     hail_home: Optional[str] = None
 
 
-@dataclass
-class VariantIndexStepConfig:
-    """Variant index step requirements.
-
-    Attributes:
-        variant_annotation_path (str): Input variant annotation path.
-        study_locus_path (str): Input study-locus path.
-        variant_index_path (str): Output variant index path.
-    """
-
-    _target_: str = "otg.variant_index.VariantIndexStep"
-    variant_annotation_path: str = MISSING
-    study_locus_path: str = MISSING
-    variant_index_path: str = MISSING
-
-
 # Register all configs
 def register_configs() -> None:
     """Register configs."""

--- a/src/otg/config.py
+++ b/src/otg/config.py
@@ -84,27 +84,6 @@ class VariantIndexStepConfig:
 
 
 @dataclass
-class ColocalisationStepConfig:
-    """Colocalisation step requirements.
-
-    Attributes:
-        study_locus_path (DictConfig): Input Study-locus path.
-        coloc_path (DictConfig): Output Colocalisation path.
-        priorc1 (float): Prior on variant being causal for trait 1.
-        priorc2 (float): Prior on variant being causal for trait 2.
-        priorc12 (float): Prior on variant being causal for traits 1 and 2.
-    """
-
-    _target_: str = "otg.colocalisation.ColocalisationStep"
-    study_locus_path: str = MISSING
-    study_index_path: str = MISSING
-    coloc_path: str = MISSING
-    priorc1: float = 1e-4
-    priorc2: float = 1e-4
-    priorc12: float = 1e-5
-
-
-@dataclass
 class VariantAnnotationStepConfig:
     """Variant annotation step requirements.
 

--- a/src/otg/config.py
+++ b/src/otg/config.py
@@ -125,20 +125,6 @@ class V2GStepConfig:
     v2g_path: str = MISSING
 
 
-@dataclass
-class UKBiobankStepConfig:
-    """UKBiobank study table ingestion step requirements.
-
-    Attributes:
-        ukbiobank_manifest (str): UKBiobank manifest of studies.
-        ukbiobank_study_index_out (str): Output path for the UKBiobank study index dataset.
-    """
-
-    _target_: str = "otg.ukbiobank.UKBiobankStep"
-    ukbiobank_manifest: str = MISSING
-    ukbiobank_study_index_out: str = MISSING
-
-
 # Register all configs
 def register_configs() -> None:
     """Register configs."""

--- a/src/otg/config.py
+++ b/src/otg/config.py
@@ -126,22 +126,6 @@ class V2GStepConfig:
 
 
 @dataclass
-class StudyLocusOverlapStepConfig:
-    """StudyLocus overlaps index step requirements.
-
-    Attributes:
-        study_locus_path (str): Input study-locus path.
-        study_index_path (str): Input study index path to extract the type of study.
-        overlaps_index_out (str): Output overlaps index path.
-    """
-
-    _target_: str = "otg.overlaps.OverlapsIndexStep"
-    study_locus_path: str = MISSING
-    study_index_path: str = MISSING
-    overlaps_index_out: str = MISSING
-
-
-@dataclass
 class UKBiobankStepConfig:
     """UKBiobank study table ingestion step requirements.
 

--- a/src/otg/config.py
+++ b/src/otg/config.py
@@ -79,52 +79,6 @@ class VariantAnnotationStepConfig:
     )
 
 
-@dataclass
-class V2GStepConfig:
-    """Variant to gene (V2G) step requirements.
-
-    Attributes:
-        variant_index_path (str): Input variant index path.
-        variant_annotation_path (str): Input variant annotation path.
-        gene_index_path (str): Input gene index path.
-        vep_consequences_path (str): Input VEP consequences path.
-        liftover_chain_file_path (str): Path to GRCh37 to GRCh38 chain file.
-        liftover_max_length_difference: Maximum length difference for liftover.
-        max_distance (int): Maximum distance to consider.
-        approved_biotypes (list[str]): List of approved biotypes.
-        intervals (dict): Dictionary of interval sources.
-        v2g_path (str): Output V2G path.
-    """
-
-    _target_: str = "otg.v2g.V2GStep"
-    variant_index_path: str = MISSING
-    variant_annotation_path: str = MISSING
-    gene_index_path: str = MISSING
-    vep_consequences_path: str = MISSING
-    liftover_chain_file_path: str = MISSING
-    liftover_max_length_difference: int = 100
-    max_distance: int = 500_000
-    approved_biotypes: List[str] = field(
-        default_factory=lambda: [
-            "protein_coding",
-            "3prime_overlapping_ncRNA",
-            "antisense",
-            "bidirectional_promoter_lncRNA",
-            "IG_C_gene",
-            "IG_D_gene",
-            "IG_J_gene",
-            "IG_V_gene",
-            "lincRNA",
-            "macro_lncRNA",
-            "non_coding",
-            "sense_intronic",
-            "sense_overlapping",
-        ]
-    )
-    intervals: Dict[str, str] = field(default_factory=dict)
-    v2g_path: str = MISSING
-
-
 # Register all configs
 def register_configs() -> None:
     """Register configs."""

--- a/src/otg/config.py
+++ b/src/otg/config.py
@@ -205,20 +205,6 @@ class StudyLocusOverlapStepConfig:
 
 
 @dataclass
-class GeneIndexStepConfig:
-    """Gene index step requirements.
-
-    Attributes:
-        target_path (str): Open targets Platform target dataset path.
-        gene_index_path (str): Output gene index path.
-    """
-
-    _target_: str = "otg.gene_index.GeneIndexStep"
-    target_path: str = MISSING
-    gene_index_path: str = MISSING
-
-
-@dataclass
 class GWASCatalogSumstatsPreprocessConfig:
     """GWAS Catalog Sumstats Preprocessing step requirements.
 

--- a/src/otg/finngen.py
+++ b/src/otg/finngen.py
@@ -5,15 +5,32 @@ from __future__ import annotations
 from dataclasses import dataclass
 from urllib.request import urlopen
 
+from omegaconf import MISSING
+
 from otg.common.session import Session
-from otg.config import FinnGenStepConfig
 from otg.datasource.finngen.study_index import FinnGenStudyIndex
 from otg.datasource.finngen.summary_stats import FinnGenSummaryStats
 
 
 @dataclass
-class FinnGenStep(FinnGenStepConfig):
-    """FinnGen ingestion step."""
+class FinnGenStep:
+    """FinnGen ingestion step.
+
+    Attributes:
+        finngen_phenotype_table_url (str): FinnGen API for fetching the list of studies.
+        finngen_release_prefix (str): Release prefix pattern.
+        finngen_sumstat_url_prefix (str): URL prefix for summary statistics location.
+        finngen_sumstat_url_suffix (str): URL prefix suffix for summary statistics location.
+        finngen_study_index_out (str): Output path for the FinnGen study index dataset.
+        finngen_summary_stats_out (str): Output path for the FinnGen summary statistics.
+    """
+
+    finngen_phenotype_table_url: str = MISSING
+    finngen_release_prefix: str = MISSING
+    finngen_sumstat_url_prefix: str = MISSING
+    finngen_sumstat_url_suffix: str = MISSING
+    finngen_study_index_out: str = MISSING
+    finngen_summary_stats_out: str = MISSING
 
     session: Session = Session()
 

--- a/src/otg/finngen.py
+++ b/src/otg/finngen.py
@@ -25,14 +25,14 @@ class FinnGenStep:
         finngen_summary_stats_out (str): Output path for the FinnGen summary statistics.
     """
 
+    session: Session = Session()
+
     finngen_phenotype_table_url: str = MISSING
     finngen_release_prefix: str = MISSING
     finngen_sumstat_url_prefix: str = MISSING
     finngen_sumstat_url_suffix: str = MISSING
     finngen_study_index_out: str = MISSING
     finngen_summary_stats_out: str = MISSING
-
-    session: Session = Session()
 
     def run(self: FinnGenStep) -> None:
         """Run FinnGen ingestion step."""

--- a/src/otg/gene_index.py
+++ b/src/otg/gene_index.py
@@ -3,19 +3,27 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from omegaconf import MISSING
+
 from otg.common.session import Session
-from otg.config import GeneIndexStepConfig
 from otg.datasource.open_targets.target import OpenTargetsTarget
 
 
 @dataclass
-class GeneIndexStep(GeneIndexStepConfig):
+class GeneIndexStep:
     """Gene index step.
 
     This step generates a gene index dataset from an Open Targets Platform target dataset.
+
+    Attributes:
+        target_path (str): Open targets Platform target dataset path.
+        gene_index_path (str): Output gene index path.
     """
 
     session: Session = Session()
+
+    target_path: str = MISSING
+    gene_index_path: str = MISSING
 
     def run(self: GeneIndexStep) -> None:
         """Run Target index step."""

--- a/src/otg/gwas_catalog.py
+++ b/src/otg/gwas_catalog.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 import hail as hl
+from omegaconf import MISSING
 
 from otg.common.session import Session
-from otg.config import GWASCatalogStepConfig
 from otg.dataset.ld_index import LDIndex
 from otg.dataset.variant_annotation import VariantAnnotation
 from otg.datasource.gwas_catalog.associations import GWASCatalogAssociations
@@ -17,10 +17,32 @@ from otg.method.pics import PICS
 
 
 @dataclass
-class GWASCatalogStep(GWASCatalogStepConfig):
-    """GWAS Catalog step."""
+class GWASCatalogStep:
+    """GWAS Catalog step.
+
+    Attributes:
+        catalog_studies_file (str): Raw GWAS catalog studies file.
+        catalog_ancestry_file (str): Ancestry annotations file from GWAS Catalog.
+        catalog_sumstats_lut (str): GWAS Catalog summary statistics lookup table.
+        catalog_associations_file (str): Raw GWAS catalog associations file.
+        variant_annotation_path (str): Input variant annotation path.
+        ld_populations (list): List of populations to include.
+        min_r2 (float): Minimum r2 to consider when considering variants within a window.
+        catalog_studies_out (str): Output GWAS catalog studies path.
+        catalog_associations_out (str): Output GWAS catalog associations path.
+    """
 
     session: Session = Session()
+
+    catalog_studies_file: str = MISSING
+    catalog_ancestry_file: str = MISSING
+    catalog_sumstats_lut: str = MISSING
+    catalog_associations_file: str = MISSING
+    variant_annotation_path: str = MISSING
+    ld_index_path: str = MISSING
+    min_r2: float = 0.5
+    catalog_studies_out: str = MISSING
+    catalog_associations_out: str = MISSING
 
     def run(self: GWASCatalogStep) -> None:
         """Run GWAS Catalog ingestion step to extract GWASCatalog Study and StudyLocus tables."""

--- a/src/otg/gwas_catalog_sumstat_preprocess.py
+++ b/src/otg/gwas_catalog_sumstat_preprocess.py
@@ -3,16 +3,27 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from omegaconf import MISSING
+
 from otg.common.session import Session
-from otg.config import GWASCatalogSumstatsPreprocessConfig
 from otg.datasource.gwas_catalog.summary_statistics import GWASCatalogSummaryStatistics
 
 
 @dataclass
-class GWASCatalogSumstatsPreprocessStep(GWASCatalogSumstatsPreprocessConfig):
-    """Step to preprocess GWAS Catalog harmonised summary stats."""
+class GWASCatalogSumstatsPreprocessStep:
+    """Step to preprocess GWAS Catalog harmonised summary stats.
+
+    Attributes:
+        raw_sumstats_path (str): Input raw GWAS Catalog summary statistics path.
+        out_sumstats_path (str): Output GWAS Catalog summary statistics path.
+        study_id (str): GWAS Catalog study identifier.
+    """
 
     session: Session = Session()
+
+    raw_sumstats_path: str = MISSING
+    out_sumstats_path: str = MISSING
+    study_id: str = MISSING
 
     def run(self: GWASCatalogSumstatsPreprocessStep) -> None:
         """Run Step."""

--- a/src/otg/ld_index.py
+++ b/src/otg/ld_index.py
@@ -1,25 +1,53 @@
 """Step to dump a filtered version of a LD matrix (block matrix) as Parquet files."""
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from typing import List
 
 import hail as hl
+from omegaconf import MISSING
 
 from otg.common.session import Session
-from otg.config import LDIndexStepConfig
 from otg.datasource.gnomad.ld import GnomADLDMatrix
 
 
 @dataclass
-class LDIndexStep(LDIndexStepConfig):
+class LDIndexStep:
     """LD index step.
 
     !!! warning "This step is resource intensive"
         Suggested params: high memory machine, 5TB of boot disk, no SSDs.
 
+    Attributes:
+        ld_matrix_template (str): Template path for LD matrix from gnomAD.
+        ld_index_raw_template (str): Template path for the variant indices correspondance in the LD Matrix from gnomAD.
+        min_r2 (float): Minimum r2 to consider when considering variants within a window.
+        grch37_to_grch38_chain_path (str): Path to GRCh37 to GRCh38 chain file.
+        ld_populations (List[str]): List of population-specific LD matrices to process.
+        ld_index_out (str): Output LD index path.
     """
 
     session: Session = Session()
+
+    ld_matrix_template: str = "gs://gcp-public-data--gnomad/release/2.1.1/ld/gnomad.genomes.r2.1.1.{POP}.common.adj.ld.bm"
+    ld_index_raw_template: str = "gs://gcp-public-data--gnomad/release/2.1.1/ld/gnomad.genomes.r2.1.1.{POP}.common.ld.variant_indices.ht"
+    min_r2: float = 0.5
+    grch37_to_grch38_chain_path: str = (
+        "gs://hail-common/references/grch37_to_grch38.over.chain.gz"
+    )
+    ld_populations: List[str] = field(
+        default_factory=lambda: [
+            "afr",  # African-American
+            "amr",  # American Admixed/Latino
+            "asj",  # Ashkenazi Jewish
+            "eas",  # East Asian
+            "fin",  # Finnish
+            "nfe",  # Non-Finnish European
+            "nwe",  # Northwestern European
+            "seu",  # Southeastern European
+        ]
+    )
+    ld_index_out: str = MISSING
 
     def run(self: LDIndexStep) -> None:
         """Run LD index dump step."""

--- a/src/otg/overlaps.py
+++ b/src/otg/overlaps.py
@@ -3,21 +3,31 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from omegaconf import MISSING
+
 from otg.common.session import Session
-from otg.config import StudyLocusOverlapStepConfig
 from otg.dataset.study_index import StudyIndex
 from otg.dataset.study_locus import StudyLocus
 from otg.dataset.study_locus_overlap import StudyLocusOverlap
 
 
 @dataclass
-class OverlapsIndexStep(StudyLocusOverlapStepConfig):
+class OverlapsIndexStep:
     """StudyLocus overlaps step.
 
     This step generates a dataset of overlapping studyLocus associations.
+
+    Attributes:
+        study_locus_path (str): Input study-locus path.
+        study_index_path (str): Input study index path to extract the type of study.
+        overlaps_index_out (str): Output overlaps index path.
     """
 
     session: Session = Session()
+
+    study_locus_path: str = MISSING
+    study_index_path: str = MISSING
+    overlaps_index_out: str = MISSING
 
     def run(self: OverlapsIndexStep) -> None:
         """Run Overlaps index step.

--- a/src/otg/ukbiobank.py
+++ b/src/otg/ukbiobank.py
@@ -7,12 +7,11 @@ from dataclasses import dataclass
 from omegaconf import MISSING
 
 from otg.common.session import Session
-from otg.config import UKBiobankStepConfig
 from otg.datasource.ukbiobank.study_index import UKBiobankStudyIndex
 
 
 @dataclass
-class UKBiobankStep(UKBiobankStepConfig):
+class UKBiobankStep:
     """UKBiobank study table ingestion step.
 
     Attributes:

--- a/src/otg/ukbiobank.py
+++ b/src/otg/ukbiobank.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from omegaconf import MISSING
+
 from otg.common.session import Session
 from otg.config import UKBiobankStepConfig
 from otg.datasource.ukbiobank.study_index import UKBiobankStudyIndex
@@ -11,9 +13,17 @@ from otg.datasource.ukbiobank.study_index import UKBiobankStudyIndex
 
 @dataclass
 class UKBiobankStep(UKBiobankStepConfig):
-    """UKBiobank study table ingestion step."""
+    """UKBiobank study table ingestion step.
+
+    Attributes:
+        ukbiobank_manifest (str): UKBiobank manifest of studies.
+        ukbiobank_study_index_out (str): Output path for the UKBiobank study index dataset.
+    """
 
     session: Session = Session()
+
+    ukbiobank_manifest: str = MISSING
+    ukbiobank_study_index_out: str = MISSING
 
     def run(self: UKBiobankStep) -> None:
         """Run UKBiobank study table ingestion step."""

--- a/src/otg/v2g.py
+++ b/src/otg/v2g.py
@@ -1,10 +1,12 @@
 """Step to generate variant annotation dataset."""
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from functools import reduce
+from typing import Dict, List
 
 import pyspark.sql.functions as f
+from omegaconf import MISSING
 
 from otg.common.Liftover import LiftOverSpark
 from otg.common.session import Session
@@ -26,9 +28,47 @@ class V2GStep(V2GStepConfig):
     2. In silico functional predictions, e.g. Variant Effect Predictor (VEP) from Ensembl.
     3. Distance between the variant and each gene's canonical transcription start site (TSS).
 
+    Attributes:
+        variant_index_path (str): Input variant index path.
+        variant_annotation_path (str): Input variant annotation path.
+        gene_index_path (str): Input gene index path.
+        vep_consequences_path (str): Input VEP consequences path.
+        liftover_chain_file_path (str): Path to GRCh37 to GRCh38 chain file.
+        liftover_max_length_difference: Maximum length difference for liftover.
+        max_distance (int): Maximum distance to consider.
+        approved_biotypes (list[str]): List of approved biotypes.
+        intervals (dict): Dictionary of interval sources.
+        v2g_path (str): Output V2G path.
     """
 
     session: Session = Session()
+
+    variant_index_path: str = MISSING
+    variant_annotation_path: str = MISSING
+    gene_index_path: str = MISSING
+    vep_consequences_path: str = MISSING
+    liftover_chain_file_path: str = MISSING
+    liftover_max_length_difference: int = 100
+    max_distance: int = 500_000
+    approved_biotypes: List[str] = field(
+        default_factory=lambda: [
+            "protein_coding",
+            "3prime_overlapping_ncRNA",
+            "antisense",
+            "bidirectional_promoter_lncRNA",
+            "IG_C_gene",
+            "IG_D_gene",
+            "IG_J_gene",
+            "IG_V_gene",
+            "lincRNA",
+            "macro_lncRNA",
+            "non_coding",
+            "sense_intronic",
+            "sense_overlapping",
+        ]
+    )
+    intervals: Dict[str, str] = field(default_factory=dict)
+    v2g_path: str = MISSING
 
     def run(self: V2GStep) -> None:
         """Run V2G dataset generation."""

--- a/src/otg/v2g.py
+++ b/src/otg/v2g.py
@@ -10,7 +10,6 @@ from omegaconf import MISSING
 
 from otg.common.Liftover import LiftOverSpark
 from otg.common.session import Session
-from otg.config import V2GStepConfig
 from otg.dataset.gene_index import GeneIndex
 from otg.dataset.intervals import Intervals
 from otg.dataset.v2g import V2G
@@ -19,7 +18,7 @@ from otg.dataset.variant_index import VariantIndex
 
 
 @dataclass
-class V2GStep(V2GStepConfig):
+class V2GStep:
     """Variant-to-gene (V2G) step.
 
     This step aims to generate a dataset that contains multiple pieces of evidence supporting the functional association of specific variants with genes. Some of the evidence types include:

--- a/src/otg/variant_annotation.py
+++ b/src/otg/variant_annotation.py
@@ -1,9 +1,11 @@
 """Step to generate variant annotation dataset."""
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from typing import List
 
 import hail as hl
+from omegaconf import MISSING
 
 from otg.common.session import Session
 from otg.config import VariantAnnotationStepConfig
@@ -15,9 +17,33 @@ class VariantAnnotationStep(VariantAnnotationStepConfig):
     """Variant annotation step.
 
     Variant annotation step produces a dataset of the type `VariantAnnotation` derived from gnomADs `gnomad.genomes.vX.X.X.sites.ht` Hail's table. This dataset is used to validate variants and as a source of annotation.
+
+    Attributes:
+        gnomad_genomes (str): Path to gnomAD genomes hail table.
+        chain_38_to_37 (str): Path to GRCh38 to GRCh37 chain file.
+        variant_annotation_path (str): Output variant annotation path.
+        populations (List[str]): List of populations to include.
     """
 
     session: Session = Session()
+
+    gnomad_genomes: str = MISSING
+    chain_38_to_37: str = MISSING
+    variant_annotation_path: str = MISSING
+    populations: List[str] = field(
+        default_factory=lambda: [
+            "afr",  # African-American
+            "amr",  # American Admixed/Latino
+            "ami",  # Amish ancestry
+            "asj",  # Ashkenazi Jewish
+            "eas",  # East Asian
+            "fin",  # Finnish
+            "nfe",  # Non-Finnish European
+            "mid",  # Middle Eastern
+            "sas",  # South Asian
+            "oth",  # Other
+        ]
+    )
 
     def run(self: VariantAnnotationStep) -> None:
         """Run variant annotation step."""

--- a/src/otg/variant_annotation.py
+++ b/src/otg/variant_annotation.py
@@ -8,12 +8,11 @@ import hail as hl
 from omegaconf import MISSING
 
 from otg.common.session import Session
-from otg.config import VariantAnnotationStepConfig
 from otg.datasource.gnomad.variants import GnomADVariants
 
 
 @dataclass
-class VariantAnnotationStep(VariantAnnotationStepConfig):
+class VariantAnnotationStep:
     """Variant annotation step.
 
     Variant annotation step produces a dataset of the type `VariantAnnotation` derived from gnomADs `gnomad.genomes.vX.X.X.sites.ht` Hail's table. This dataset is used to validate variants and as a source of annotation.

--- a/src/otg/variant_index.py
+++ b/src/otg/variant_index.py
@@ -3,21 +3,31 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from omegaconf import MISSING
+
 from otg.common.session import Session
-from otg.config import VariantIndexStepConfig
 from otg.dataset.study_locus import StudyLocus
 from otg.dataset.variant_annotation import VariantAnnotation
 from otg.dataset.variant_index import VariantIndex
 
 
 @dataclass
-class VariantIndexStep(VariantIndexStepConfig):
+class VariantIndexStep:
     """Variant index step.
 
     Using a `VariantAnnotation` dataset as a reference, this step creates and writes a dataset of the type `VariantIndex` that includes only variants that have disease-association data with a reduced set of annotations.
+
+    Attributes:
+        variant_annotation_path (str): Input variant annotation path.
+        study_locus_path (str): Input study-locus path.
+        variant_index_path (str): Output variant index path.
     """
 
     session: Session = Session()
+
+    variant_annotation_path: str = MISSING
+    study_locus_path: str = MISSING
+    variant_index_path: str = MISSING
 
     def run(self: VariantIndexStep) -> None:
         """Run variant index step to only variants in study-locus sets."""


### PR DESCRIPTION
Closes https://github.com/opentargets/issues/issues/3132.

For each of the existing steps:
* Moved the list of attributes and their descriptions into the main `*Step` class;
* Adjusted `my_STEP.yaml` files so that they populate the appropriate class directly via `_target_`;
* Removed the inheritance from a `*StepConfig` class;
* Since it is no longer required, removed the `*StepConfig` class and the accompanying `cs.store` call.

As can be seen from the diff (± lines), this reduces the code required to define the same configuration by about 35%, and removes two entities: `*StepConfig` classes and `cs.store` calls.

At the same time, we retain the full flexibility, as everything can still be configured through YAML files, overridden from the command line argument or in `omegaconf`'s `instantiate` call; and the `*Step` classes can still be inherited and modified (although we don't use this at the moment).