### PR TITLE
Dependabot to monitor airflow docker

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -26,3 +26,14 @@ updates:
     commit-message:
       prefix: "chore"
       include: "scope"
+
+  - package-ecosystem: "docker"
+    directory: "/src/airflow/"
+    schedule:
+      interval: "weekly"
+      time: "09:30"
+      day: "monday"
+      timezone: "Europe/London"
+    commit-message:
+      prefix: "build"
+      include: "scope"


### PR DESCRIPTION
It should ensure the `src/airflow/Dockerfile` gets updates, but it hasn't been tested. 