### PR TITLE
Implement Preprocess DAG following recent architecture updates

### DIFF
--- a/src/airflow/dags/__init__.py
+++ b/src/airflow/dags/__init__.py
@@ -1,3 +1,0 @@
-"""Airflow DAGs which define the workflows of the pipeline."""
-
-from __future__ import annotations

--- a/src/airflow/dags/__init__.py
+++ b/src/airflow/dags/__init__.py
@@ -1,0 +1,3 @@
+"""Airflow DAGs which define the workflows of the pipeline."""
+
+from __future__ import annotations

--- a/src/airflow/dags/common_airflow.py
+++ b/src/airflow/dags/common_airflow.py
@@ -24,16 +24,21 @@ zone = "europe-west1-d"
 image_version = "2.1"
 
 
-# Executable configuration.
+# Cluster init configuration.
 initialisation_base_path = (
     f"gs://genetics_etl_python_playground/initialisation/{otg_version}"
 )
-python_cli = f"{initialisation_base_path}/cli.py"
 config_tar = f"{initialisation_base_path}/config.tar.gz"
 package_wheel = f"{initialisation_base_path}/otgenetics-{otg_version}-py3-none-any.whl"
 initialisation_executable_file = [
     f"{initialisation_base_path}/install_dependencies_on_cluster.sh"
 ]
+
+
+# CLI configuration.
+cluster_config_dir = "/config"
+config_name = "config"
+python_cli = "cli.py"
 
 
 # Shared DAG construction parameters.
@@ -150,6 +155,20 @@ def submit_pyspark_job(
                 "spark.kryo.registrator": "is.hail.kryo.HailKryoRegistrator",
             },
         },
+    )
+
+
+def submit_step(cluster_name, step_id):
+    """Submit a PySpark job to execute a specific CLI step."""
+    return submit_pyspark_job(
+        cluster_name=cluster_name,
+        task_id=step_id,
+        python_module_path=python_cli,
+        args=[
+            f"step={step_id}",
+            f"--config-dir={cluster_config_dir}",
+            f"--config-name={config_name}",
+        ],
     )
 
 

--- a/src/airflow/dags/common_airflow.py
+++ b/src/airflow/dags/common_airflow.py
@@ -216,3 +216,13 @@ def delete_cluster(cluster_name: str) -> DataprocDeleteClusterOperator:
         trigger_rule=TriggerRule.ALL_DONE,
         deferrable=True,
     )
+
+
+def generate_dag(cluster_name, tasks):
+    """For a list of tasks, generate a complete DAG."""
+    return (
+        create_cluster(cluster_name)
+        >> install_dependencies(cluster_name)
+        >> tasks
+        >> delete_cluster(cluster_name)
+    )

--- a/src/airflow/dags/common_airflow.py
+++ b/src/airflow/dags/common_airflow.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 import pendulum
+import yaml
 from airflow.providers.google.cloud.operators.dataproc import (
     ClusterGenerator,
     DataprocCreateClusterOperator,
@@ -216,6 +217,13 @@ def delete_cluster(cluster_name: str) -> DataprocDeleteClusterOperator:
         trigger_rule=TriggerRule.ALL_DONE,
         deferrable=True,
     )
+
+
+def read_yaml_config(config_path):
+    """Parse a YAMl config file and do all necessary checks."""
+    assert config_path.exists(), f"YAML config path {config_path} does not exist."
+    with open(config_path, "r") as config_file:
+        return yaml.safe_load(config_file)
 
 
 def generate_dag(cluster_name, tasks):

--- a/src/airflow/dags/dag_genetics_etl.py
+++ b/src/airflow/dags/dag_genetics_etl.py
@@ -11,7 +11,7 @@ from common_airflow import (
     install_dependencies,
     shared_dag_args,
     shared_dag_kwargs,
-    submit_pyspark_job,
+    submit_step,
 )
 
 SOURCE_CONFIG_FILE_PATH = Path(__file__).parent / "configs" / "dag.yaml"
@@ -38,15 +38,9 @@ with DAG(
         for step in steps:
             # Define task for the current step.
             step_id = step["id"]
-            this_task = submit_pyspark_job(
+            this_task = submit_step(
                 cluster_name=CLUSTER_NAME,
-                task_id=step_id,
-                python_module_path=PYTHON_CLI,
-                args=[
-                    f"step={step_id}",
-                    f"--config-dir={CLUSTER_CONFIG_DIR}",
-                    f"--config-name={CONFIG_NAME}",
-                ],
+                step_id=step_id,
             )
             # Chain prerequisites.
             tasks[step_id] = this_task

--- a/src/airflow/dags/dag_genetics_etl.py
+++ b/src/airflow/dags/dag_genetics_etl.py
@@ -3,9 +3,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import common_airflow as common
 from airflow.models.dag import DAG
-
-from . import common_airflow as common
 
 SOURCE_CONFIG_FILE_PATH = Path(__file__).parent / "configs" / "dag.yaml"
 CLUSTER_NAME = "otg-etl"

--- a/src/airflow/dags/dag_genetics_etl.py
+++ b/src/airflow/dags/dag_genetics_etl.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import yaml
 from airflow.models.dag import DAG
 
 from . import common_airflow as common
@@ -18,24 +17,19 @@ with DAG(
     default_args=common.shared_dag_args,
     **common.shared_dag_kwargs,
 ):
-    assert (
-        SOURCE_CONFIG_FILE_PATH.exists()
-    ), f"Config path {SOURCE_CONFIG_FILE_PATH} does not exist."
-
-    with open(SOURCE_CONFIG_FILE_PATH, "r") as config_file:
-        # Parse and define all steps and their prerequisites.
-        tasks = {}
-        steps = yaml.safe_load(config_file)
-        for step in steps:
-            # Define task for the current step.
-            step_id = step["id"]
-            this_task = common.submit_step(
-                cluster_name=CLUSTER_NAME,
-                step_id=step_id,
-            )
-            # Chain prerequisites.
-            tasks[step_id] = this_task
-            for prerequisite in step.get("prerequisites", []):
-                this_task.set_upstream(tasks[prerequisite])
-        # Construct the DAG with all tasks.
-        dag = common.generate_dag(cluster_name=CLUSTER_NAME, tasks=list(tasks.values()))
+    # Parse and define all steps and their prerequisites.
+    tasks = {}
+    steps = common.read_yaml_config(SOURCE_CONFIG_FILE_PATH)
+    for step in steps:
+        # Define task for the current step.
+        step_id = step["id"]
+        this_task = common.submit_step(
+            cluster_name=CLUSTER_NAME,
+            step_id=step_id,
+        )
+        # Chain prerequisites.
+        tasks[step_id] = this_task
+        for prerequisite in step.get("prerequisites", []):
+            this_task.set_upstream(tasks[prerequisite])
+    # Construct the DAG with all tasks.
+    dag = common.generate_dag(cluster_name=CLUSTER_NAME, tasks=list(tasks.values()))

--- a/src/airflow/dags/dag_preprocess.py
+++ b/src/airflow/dags/dag_preprocess.py
@@ -7,7 +7,7 @@ from airflow.models.dag import DAG
 
 from . import common_airflow as common
 
-CLUSTER_NAME = "workflow-otg-cluster"
+CLUSTER_NAME = "otg-preprocess"
 
 ALL_STEPS = [
     "finngen",
@@ -20,12 +20,8 @@ with DAG(
     default_args=common.shared_dag_args,
     **common.shared_dag_kwargs,
 ):
-    (
-        common.create_cluster(CLUSTER_NAME)
-        >> common.install_dependencies(CLUSTER_NAME)
-        >> [
-            common.submit_step(cluster_name=CLUSTER_NAME, step_id=step)
-            for step in ALL_STEPS
-        ]
-        >> common.delete_cluster(CLUSTER_NAME)
-    )
+    all_tasks = [
+        common.submit_step(cluster_name=CLUSTER_NAME, step_id=step)
+        for step in ALL_STEPS
+    ]
+    dag = common.generate_dag(cluster_name=CLUSTER_NAME, tasks=all_tasks)

--- a/src/airflow/dags/dag_preprocess.py
+++ b/src/airflow/dags/dag_preprocess.py
@@ -1,0 +1,31 @@
+"""Airflow DAG for the Preprocess part of the pipeline."""
+from __future__ import annotations
+
+from pathlib import Path
+
+from airflow.models.dag import DAG
+
+from . import common_airflow as common
+
+CLUSTER_NAME = "workflow-otg-cluster"
+
+ALL_STEPS = [
+    "finngen",
+]
+
+
+with DAG(
+    dag_id=Path(__file__).stem,
+    description="Open Targets Genetics — Preprocess",
+    default_args=common.shared_dag_args,
+    **common.shared_dag_kwargs,
+):
+    (
+        common.create_cluster(CLUSTER_NAME)
+        >> common.install_dependencies(CLUSTER_NAME)
+        >> [
+            common.submit_step(cluster_name=CLUSTER_NAME, step_id=step)
+            for step in ALL_STEPS
+        ]
+        >> common.delete_cluster(CLUSTER_NAME)
+    )

--- a/src/airflow/dags/dag_preprocess.py
+++ b/src/airflow/dags/dag_preprocess.py
@@ -3,9 +3,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import common_airflow as common
 from airflow.models.dag import DAG
-
-from . import common_airflow as common
 
 CLUSTER_NAME = "otg-preprocess"
 

--- a/src/otg/datasource/finngen/__init__.py
+++ b/src/otg/datasource/finngen/__init__.py
@@ -1,3 +1,3 @@
-"""GWAS Catalog Data Source."""
+"""FinnGen datasource classes."""
 
 from __future__ import annotations

--- a/src/otg/datasource/finngen/summary_stats.py
+++ b/src/otg/datasource/finngen/summary_stats.py
@@ -20,7 +20,7 @@ class FinnGenSummaryStats(SummaryStatistics):
     """Summary statistics dataset for FinnGen."""
 
     @classmethod
-    def from_finngen_harmonized_summary_stats(
+    def from_source(
         cls: type[FinnGenSummaryStats],
         summary_stats_df: DataFrame,
     ) -> FinnGenSummaryStats:

--- a/tests/datasource/finngen/test_finngen_summary_stats.py
+++ b/tests/datasource/finngen/test_finngen_summary_stats.py
@@ -13,8 +13,6 @@ def test_finngen_summary_stats_from_source(
 ) -> None:
     """Test summary statistics from source."""
     assert isinstance(
-        FinnGenSummaryStats.from_finngen_harmonized_summary_stats(
-            sample_finngen_summary_stats
-        ),
+        FinnGenSummaryStats.from_source(sample_finngen_summary_stats),
         SummaryStatistics,
     )


### PR DESCRIPTION
Closes https://github.com/opentargets/issues/issues/3106.

* Added three new functions to the `common_airflow` module: `submit_step`, `read_yaml_config`, and `generate_dag`.
* Updated the ETL DAG to use these functions, making it even more readable and focused on logic.
* Implemented a new separate DAG for the Preprocess part, as we discussed.
* Made some refactoring changes specific to FinnGen ingestion.