### PR TITLE
chore(dag): add l2g and overlaps steps to `dag.yaml`

### DIFF
--- a/src/airflow/dags/configs/dag.yaml
+++ b/src/airflow/dags/configs/dag.yaml
@@ -16,3 +16,16 @@
     - "gene_index"
 - id: "finngen"
 - id: "ukbiobank"
+- id: "study_locus_overlap"
+  prerequisites:
+    - "gwas_catalog"
+    - "finngen"
+    - "ukbiobank"
+- id: "locus_to_gene"
+  prerequisites:
+    - "gwas_catalog"
+    - "finngen"
+    - "ukbiobank"
+    - "variant_index"
+    - "v2g"
+    - "study_locus_overlap"


### PR DESCRIPTION
L2G's step was defined in the previous `workflow/dag`, and it was not ported in the transition to `airflow/dag`.
Adding the L2G and overlaps step to Airflow's DAG.