### PR TITLE
Re-enable and fix the `test_no_import_errors` Airflow DAG test

### DIFF
--- a/tests/airflow/test_dag.py
+++ b/tests/airflow/test_dag.py
@@ -6,16 +6,20 @@ from airflow.models import DagBag
 
 
 @pytest.fixture(params=["./src/airflow/dags"])
-def dag_bag(request):
+def dag_bag(request, monkeypatch: pytest.MonkeyPatch):
     """Return a DAG bag for testing."""
+    # It's important to change directory before importing DAGs, because this is way Airflow works in production: the
+    # dags/ directory serves as a root (and indeed $PYTHONPATH) for all DAGS contained therein.  Using Monkeypatch
+    # ensures that the other tests are not affected.
+    monkeypatch.chdir(request.param)
     return DagBag(dag_folder=request.param, include_examples=False)
 
 
-# def test_no_import_errors(dag_bag):
-#     """Test for import errors."""
-#     assert (
-#         not dag_bag.import_errors
-#     ), f"DAG import failures. Errors: {dag_bag.import_errors}"
+def test_no_import_errors(dag_bag):
+    """Test for import errors."""
+    assert (
+        not dag_bag.import_errors
+    ), f"DAG import failures. Errors: {dag_bag.import_errors}"
 
 
 def test_requires_tags(dag_bag):


### PR DESCRIPTION
Closes https://github.com/opentargets/issues/issues/3140.

For properly resolving all imports, we should change the working directory to `dags/` (which is the way Airflow does it in production), and since this wasn't done, the tests were failing.

Because we are using the `MonkeyPatch` class, directory is only changed for the import fixture and does not affect any other tests in the repository.