### PR TITLE
A better way to fix DAG import test

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,6 +91,10 @@ exclude = ["dist"]
 
 [tool.pytest.ini_options]
 addopts = "-n auto --doctest-modules --cov=src/ --cov-report=xml"
+pythonpath = [
+    ".",
+    "./src/airflow/dags"
+]
 
 [[tool.mypy.overrides]]
 module = "google.protobuf.duration_pb2"

--- a/tests/airflow/test_dag.py
+++ b/tests/airflow/test_dag.py
@@ -6,12 +6,8 @@ from airflow.models import DagBag
 
 
 @pytest.fixture(params=["./src/airflow/dags"])
-def dag_bag(request, monkeypatch: pytest.MonkeyPatch):
+def dag_bag(request):
     """Return a DAG bag for testing."""
-    # It's important to change directory before importing DAGs, because this is way Airflow works in production: the
-    # dags/ directory serves as a root (and indeed $PYTHONPATH) for all DAGS contained therein.  Using Monkeypatch
-    # ensures that the other tests are not affected.
-    monkeypatch.chdir(request.param)
     return DagBag(dag_folder=request.param, include_examples=False)
 
 


### PR DESCRIPTION
Closes https://github.com/opentargets/issues/issues/3140 (again -__-)

After the fix in https://github.com/opentargets/genetics_etl_python/pull/218 it turned out that pytest's `DagBag` import and the actual Airflow deployment still differ in how they treat imports. In particular, "from . import airflow_common" imports work in pytest, but not in the actual Airflow set up.

After digging further, it looks like the proper way to make pytest evaluate those files is to extend its PYTHONPATH (_not_ PATH and _not_ the current working directory).

My apologies for the mix-up, the new configuration should now fix things for good.

