### PR TITLE
Airflow set up, part 3: Fixing issue with `docker compose` syntax

### DIFF
--- a/docs/development/airflow.md
+++ b/docs/development/airflow.md
@@ -65,13 +65,13 @@ mv .env.tmp .env
 Before starting Airflow, initialise the database:
 
 ```bash
-docker compose up airflow-init
+docker-compose up airflow-init
 ```
 
 Now start all services:
 
 ```bash
-docker compose up -d
+docker-compose up -d
 ```
 
 Airflow UI will now be available at `http://localhost:8080/`. Default username and password are both `airflow`.
@@ -90,13 +90,13 @@ docker ps
 To stop Airflow, run:
 
 ```bash
-docker compose down
+docker-compose down
 ```
 
 To cleanup the Airflow database, run:
 
 ```bash
-docker compose down --volumes --remove-orphans
+docker-compose down --volumes --remove-orphans
 ```
 
 ### Advanced configuration

--- a/docs/development/airflow.md
+++ b/docs/development/airflow.md
@@ -65,13 +65,13 @@ mv .env.tmp .env
 Before starting Airflow, initialise the database:
 
 ```bash
-docker-compose up airflow-init
+docker compose up airflow-init
 ```
 
 Now start all services:
 
 ```bash
-docker-compose up -d
+docker compose up -d
 ```
 
 Airflow UI will now be available at `http://localhost:8080/`. Default username and password are both `airflow`.
@@ -90,13 +90,13 @@ docker ps
 To stop Airflow, run:
 
 ```bash
-docker-compose down
+docker compose down
 ```
 
 To cleanup the Airflow database, run:
 
 ```bash
-docker-compose down --volumes --remove-orphans
+docker compose down --volumes --remove-orphans
 ```
 
 ### Advanced configuration

--- a/docs/development/airflow.md
+++ b/docs/development/airflow.md
@@ -10,6 +10,9 @@ This section describes how to set up a local Airflow server which will orchestra
 !!!warning macOS Docker memory allocation
     On macOS, the default amount of memory available for Docker might not be enough to get Airflow up and running. Allocate at least 4GB of memory for the Docker Engine (ideally 8GB). [More info](https://airflow.apache.org/docs/apache-airflow/stable/howto/docker-compose/index.html#)
 
+!!!warning Making sure the Docker set up is up to date
+    If you installed Docker a while ago, it is possible that it was done using unofficial packages, like `docker.io` in Debian/Ubuntu. This may cause various errors when trying to run commands below, particularly `docker compose`. The solution in this case is to uninstall Docker and reinstall from the official source. Follow instructions [here](https://docs.docker.com/engine/install/) for your platform.
+
 
 ## Configure Airflow access to Google Cloud Platform
 


### PR DESCRIPTION
Closes https://github.com/opentargets/issues/issues/3143.

Third and final part of updates for https://github.com/opentargets/issues/issues/3143, split for readability and easier review.

For me, on Ubuntu, `docker-compose` (with hyphen) works, while `docker compose` (with space) does not:
```
docker: 'compose' is not a docker command.
See 'docker --help'
```

I installed it in a standard way via apt (`sudo apt install docker.io`).

It looks like this distinction has a long history: https://github.com/docker/compose/issues/8630; and certainly there are fixes and workarounds about this.

However, I was wondering: @d0choa @ireneisdoomed, does `docker-compose` (with hyphen) work for you on your machines?
* If yes, we can leave this option as seemingly the most compatible.
* If no, then I'll amend this PR and specify this discrepancy and potential workarounds.
