### PR TITLE
feat(airflow): move `variant_annotation` and `ldindex` steps to preprocessing dag

### DIFF
--- a/src/airflow/dags/configs/dag.yaml
+++ b/src/airflow/dags/configs/dag.yaml
@@ -1,10 +1,8 @@
 - id: "gene_index"
 - id: "variant_annotation"
-- id: "ld_index"
 - id: "gwas_catalog"
   prerequisites:
     - "variant_annotation"
-    - "ld_index"
 - id: "variant_index"
   prerequisites:
     - "variant_annotation"

--- a/src/airflow/dags/configs/dag.yaml
+++ b/src/airflow/dags/configs/dag.yaml
@@ -1,16 +1,11 @@
 - id: "gene_index"
-- id: "variant_annotation"
 - id: "gwas_catalog"
-  prerequisites:
-    - "variant_annotation"
 - id: "variant_index"
   prerequisites:
-    - "variant_annotation"
     - "gwas_catalog"
 - id: "v2g"
   prerequisites:
     - "variant_index"
-    - "variant_annotation"
     - "gene_index"
 - id: "finngen"
 - id: "ukbiobank"

--- a/src/airflow/dags/dag_preprocess.py
+++ b/src/airflow/dags/dag_preprocess.py
@@ -10,6 +10,7 @@ CLUSTER_NAME = "otg-preprocess"
 
 ALL_STEPS = [
     "finngen",
+    "ld_index",
 ]
 
 

--- a/src/airflow/dags/dag_preprocess.py
+++ b/src/airflow/dags/dag_preprocess.py
@@ -8,10 +8,7 @@ from airflow.models.dag import DAG
 
 CLUSTER_NAME = "otg-preprocess"
 
-ALL_STEPS = [
-    "finngen",
-    "ld_index",
-]
+ALL_STEPS = ["finngen", "ld_index", "variant_annotation"]
 
 
 with DAG(


### PR DESCRIPTION
Moving steps between DAGs is trivial.
This PR includes:
- relocation of `variant_annotation` and `ldindex` steps to preprocessing dag, these are datasets that only need changing when a major gnomad version is released. They also happen to be the steps that require the most time to run
- this way we can tweak the ETL DAG without worrying about messing our input data
- On the flip side, it becomes less obvious to know the dependencies of our ETL steps

**Current ETL DAG:**
<img width="882" alt="image" src="https://github.com/opentargets/genetics_etl_python/assets/45119610/9afd1a16-6340-4543-8daf-233d7602c607">

**Current Preprocessing DAG:**
<img width="882" alt="image" src="https://github.com/opentargets/genetics_etl_python/assets/45119610/80b2c453-225e-45f5-9f9b-a39cef5516aa">
