### PR TITLE
Enable autoscaling, tune cluster parameters, add docs

### DIFF
--- a/docs/development/airflow.md
+++ b/docs/development/airflow.md
@@ -1,4 +1,4 @@
-# Airflow workflow
+# Airflow configuration
 
 This section describes how to set up a local Airflow server which will orchestrate running workflows in Google Cloud Platform. This is useful for testing and debugging, but for production use, it is recommended to run Airflow on a dedicated server.
 

--- a/docs/development/workflows.md
+++ b/docs/development/workflows.md
@@ -1,0 +1,31 @@
+# Pipeline workflows
+
+This page describes the high level components of the pipeline, which are organised as Airflow DAGs (directed acyclic graphs).
+
+
+## Note on DAGs and Dataproc clusters
+
+Each DAG consists of the following general stages:
+
+1. Create cluster (if it already exists, this step is skipped)
+
+1. Install dependencies on the cluster
+
+1. Run data processing steps for this DAG
+
+1. Delete the cluster
+
+
+Within a DAG, all data processing steps run on the same Dataproc cluster as separate jobs.
+
+There is no need to configure DAGs or steps depending on the size of the input data. Clusters have autoscaling enabled, which means they will increase or decrease the number of worker VMs to accommodate the load.
+
+
+## DAG 1: Preprocess
+
+This DAG contains steps which are only supposed to be run once, or very rarely. They ingest external data and apply bespoke transformations specific for each particular data source. The output is normalised according to the data schemas used by the pipeline.
+
+
+## DAG 2: ETL
+
+The ETL DAG takes the inputs of the previous step and performs the main algorithmic processing. This processing is supposed to be data source agnostic.

--- a/src/airflow/dags/common_airflow.py
+++ b/src/airflow/dags/common_airflow.py
@@ -23,6 +23,7 @@ GCP_PROJECT = "open-targets-genetics-dev"
 GCP_REGION = "europe-west1"
 GCP_ZONE = "europe-west1-d"
 GCP_DATAPROC_IMAGE = "2.1"
+GCP_AUTOSCALING_POLICY = "otg-etl"
 
 
 # Cluster init configuration.
@@ -89,6 +90,7 @@ def create_cluster(
             "PACKAGE": PACKAGE_WHEEL,
         },
         idle_delete_ttl=None,
+        autoscaling_policy=f"projects/{GCP_PROJECT}/regions/{GCP_REGION}/autoscalingPolicies/{GCP_AUTOSCALING_POLICY}",
     ).make()
     return DataprocCreateClusterOperator(
         task_id="create_cluster",

--- a/src/airflow/dags/common_airflow.py
+++ b/src/airflow/dags/common_airflow.py
@@ -46,7 +46,7 @@ PYTHON_CLI = "cli.py"
 # Shared DAG construction parameters.
 shared_dag_args = dict(
     owner="Open Targets Data Team",
-    retries=3,
+    retries=1,
 )
 shared_dag_kwargs = dict(
     tags=["genetics_etl", "experimental"],

--- a/src/airflow/dags/common_airflow.py
+++ b/src/airflow/dags/common_airflow.py
@@ -60,7 +60,7 @@ def create_cluster(
     cluster_name: str,
     master_machine_type: str = "n1-standard-4",
     worker_machine_type: str = "n1-standard-16",
-    num_workers: int = 0,
+    num_workers: int = 2,
 ) -> DataprocCreateClusterOperator:
     """Generate an Airflow task to create a Dataproc cluster. Common parameters are reused, and varying parameters can be specified as needed.
 


### PR DESCRIPTION
Closes https://github.com/opentargets/issues/issues/3142.

Now that https://github.com/opentargets/issues/issues/3145 is addressed, enabling autoscaling is easy ;-)

I have verified that it works using LD index as an example. I didn't run it to completion, but it has a very characteristic CPU load profile where we can immediately see the difference. On a single 96 core VM, graph width = 6 hours:
<img src=https://github.com/opentargets/genetics_etl_python/assets/10669118/07de8d07-ca2a-45d7-ad9c-bda26215fc58 width=500>

And on an a autoscaled cluster of 20 VMs (plot width = same 6 hours):
<img src=https://github.com/opentargets/genetics_etl_python/assets/10669118/984ca24d-ed2f-4f5b-a740-99f2e5612c2c width=500>

(@ireneisdoomed Sorry again for the clash, I didn't immediately realise you were running the step at the same time as I did — will be more vigilant going forward & change the output paths, etc.)

The cluster was very stable at 2 primary + 20 secondary workers (I even tested randomly killing a few secondary workers — it recovers beautifully), so I increased the maximum number of secondary VMs to 50 in the autoscaling policy. I'll monitor performance and adjust as needed going forward.

I also added some basic documentation on the high level organisation of the pipeline, including which DAGs we have, and how autoscaling works. (Feel free to suggest alternative places where this piece of documentation can be moved if you have some ideas)