### PR TITLE
feat: hydra full error on dataproc

### DIFF
--- a/utils/install_dependencies_on_cluster.sh
+++ b/utils/install_dependencies_on_cluster.sh
@@ -39,6 +39,10 @@ function install_pip() {
 }
 
 function main() {
+    # more meaningful errors from hydra
+    echo "export HYDRA_FULL_ERROR=1" | tee --append /etc/profile
+    source /etc/profile
+
     if [[ -z "${PACKAGE}" ]]; then
         echo "ERROR: Must specify PACKAGE metadata key"
         exit 1


### PR DESCRIPTION
Use HYDRA_FULL_ERROR=1 in dataproc by default to have more verbose errors. Otherwise, errors are occasionally so succinct that it's hard to know what's happening.

After failing with a few setups, this produces the intended results.