### PR TITLE
fix: wrong python file uri in airflow

### DIFF
--- a/src/airflow/dags/common_airflow.py
+++ b/src/airflow/dags/common_airflow.py
@@ -151,7 +151,7 @@ def submit_pyspark_job(
         task_id=task_id,
         job_type="pyspark_job",
         job_specification={
-            "main_python_file_uri": f"{INITIALISATION_BASE_PATH}/{python_module_path}",
+            "main_python_file_uri": python_module_path,
             "args": args,
             "properties": {
                 "spark.jars": "/opt/conda/miniconda3/lib/python3.10/site-packages/hail/backend/hail-all-spark.jar",


### PR DESCRIPTION
Python module path was malformed. It looked like `gs:.../.../gs:../.../.../` due to excessive concatenation of variables.

This fix should rescue all airflow runs. @ireneisdoomed came out with the same fix separately. 