### PR TITLE
fix(gwas_catalog): clump associations, remove hail and style fixes

### DIFF
--- a/src/otg/gwas_catalog.py
+++ b/src/otg/gwas_catalog.py
@@ -1,9 +1,8 @@
-"""Step to generate variant annotation dataset."""
+"""Step to process GWAS Catalog associations."""
 from __future__ import annotations
 
 from dataclasses import dataclass
 
-import hail as hl
 from omegaconf import MISSING
 
 from otg.common.session import Session
@@ -19,6 +18,8 @@ from otg.method.pics import PICS
 @dataclass
 class GWASCatalogStep:
     """GWAS Catalog ingestion step to extract GWASCatalog Study and StudyLocus tables.
+
+    !!!note This step currently only processes the GWAS Catalog curated list of top hits.
 
     Attributes:
         session (Session): Session object.
@@ -46,45 +47,35 @@ class GWASCatalogStep:
 
     def __post_init__(self: GWASCatalogStep) -> None:
         """Run step."""
-        hl.init(sc=self.session.spark.sparkContext, log="/dev/null")
-        # All inputs:
-        # Variant annotation dataset
+        # Extract
         va = VariantAnnotation.from_parquet(self.session, self.variant_annotation_path)
-        # GWAS Catalog raw study information
         catalog_studies = self.session.spark.read.csv(
             self.catalog_studies_file, sep="\t", header=True
         )
-        # GWAS Catalog ancestry information
         ancestry_lut = self.session.spark.read.csv(
             self.catalog_ancestry_file, sep="\t", header=True
         )
-        # GWAS Catalog summary statistics information
         sumstats_lut = self.session.spark.read.csv(
             self.catalog_sumstats_lut, sep="\t", header=False
         )
-        # GWAS Catalog raw association information
         catalog_associations = self.session.spark.read.csv(
             self.catalog_associations_file, sep="\t", header=True
         )
-        # LD index dataset
         ld_index = LDIndex.from_parquet(self.session, self.ld_index_path)
 
-        # Transform:
-        # GWAS Catalog study index and study-locus splitted
+        # Transform
         study_index, study_locus = GWASCatalogStudySplitter.split(
             GWASCatalogStudyIndex.from_source(
                 catalog_studies, ancestry_lut, sumstats_lut
             ),
             GWASCatalogAssociations.from_source(catalog_associations, va),
         )
-
-        # Annotate LD information and clump associations dataset
-        study_locus_ld = LDAnnotator.ld_annotate(study_locus, study_index, ld_index)
-
-        # Fine-mapping LD-clumped study-locus using PICS
+        study_locus_ld = LDAnnotator.ld_annotate(
+            study_locus, study_index, ld_index
+        ).clump()
         finemapped_study_locus = PICS.finemap(study_locus_ld).annotate_credible_sets()
 
-        # Write:
+        # Load
         study_index.df.write.mode(self.session.write_mode).parquet(
             self.catalog_studies_out
         )


### PR DESCRIPTION
This PR includes:
- I've added calling `clump()` which got removed accidentally
- Removal of hail initialisation (on a side note, the fact that Hail was initialising despite having set `start_hail=False` makes me think that sessions are not overwritten.
- Minor style changes

The step runs in 20'