### PR TITLE
feat(ld): minor improvements to gnomad matrix methods

### DIFF
--- a/src/otg/common/spark_helpers.py
+++ b/src/otg/common/spark_helpers.py
@@ -3,14 +3,14 @@ from __future__ import annotations
 
 import re
 import sys
-from typing import TYPE_CHECKING, Iterable, Optional
+from typing import TYPE_CHECKING, Any, Iterable, Optional
 
 import pyspark.sql.functions as f
 import pyspark.sql.types as t
 from pyspark.ml import Pipeline
 from pyspark.ml.feature import MinMaxScaler, VectorAssembler
 from pyspark.ml.functions import vector_to_array
-from pyspark.sql import Window
+from pyspark.sql import Row, Window
 from pyspark.sql.types import FloatType
 from scipy.stats import norm
 
@@ -373,3 +373,29 @@ def pivot_df(
             ],
         )
     )
+
+
+def get_value_from_row(row: Row, column: str) -> Any:
+    """Extract index value from a row if exists.
+
+    Args:
+        row (Row): One row from a dataframe
+        column (str): column label we want to extract.
+
+    Returns:
+        Any: value of the column in the row
+
+    Raises:
+        ValueError: if the column is not in the row
+
+    Examples:
+        >>> get_value_from_row(Row(geneName="AR", chromosome="X"), "chromosome")
+        'X'
+        >>> get_value_from_row(Row(geneName="AR", chromosome="X"), "disease")
+        Traceback (most recent call last):
+        ...
+        ValueError: Column disease not found in row Row(geneName='AR', chromosome='X')
+    """
+    if column not in row:
+        raise ValueError(f"Column {column} not found in row {row}")
+    return row[column]

--- a/tests/datasource/gnomad/test_gnomad_ld.py
+++ b/tests/datasource/gnomad/test_gnomad_ld.py
@@ -89,27 +89,55 @@ class TestGnomADLDMatrixVariants:
             ld_index_raw_template="tests/data_samples/example_{POP}.ht",
             grch37_to_grch38_chain_path="tests/data_samples/grch37_to_grch38.over.chain",
         )
-
-    @pytest.fixture(scope="class")
-    def ld_slice(self: TestGnomADLDMatrixVariants) -> DataFrame | None:
-        """Generate a resolved LD slice."""
-        return self.gnomad_ld_matrix.get_ld_variants(
-            gnomad_ancestry="test-pop",  # observed[0],
-            chromosome="1",  # observed[1],
-            start=10025,  # observed[2],
-            end=10075,  # observed[3],
+        self.ld_slice = self.gnomad_ld_matrix.get_ld_variants(
+            gnomad_ancestry="test-pop",
+            chromosome="1",
+            start=10025,
+            end=10075,
         )
+        self.ld_empty_slice = self.gnomad_ld_matrix.get_ld_variants(
+            gnomad_ancestry="test-pop",
+            chromosome="1",
+            start=0,
+            end=1,
+        )
+
+    # @pytest.fixture(scope="class")
+    # def ld_slice(self: TestGnomADLDMatrixVariants) -> DataFrame | None:
+    #     """Generate a resolved LD slice."""
+    #     return self.gnomad_ld_matrix.get_ld_variants(
+    #         gnomad_ancestry="test-pop",
+    #         chromosome="1",
+    #         start=10025,
+    #         end=10075,
+    #     )
+
+    # @pytest.fixture(scope="class")
+    # def ld_empty_slice(self: TestGnomADLDMatrixVariants) -> DataFrame | None:
+    #     """Generate a resolved LD slice."""
+    #     return self.gnomad_ld_matrix.get_ld_variants(
+    #         gnomad_ancestry="test-pop",
+    #         chromosome="1",
+    #         start=0,
+    #         end=1,
+    #     )
 
     def test_get_ld_variants__type(
         self: TestGnomADLDMatrixVariants,
-        ld_slice: DataFrame
-        # self: TestGnomADLDMatrixVariants, observed: list[Any], expected: list[Any]
     ) -> None:
         """Testing if the function returns the right type."""
         # Do we have the right type?
-        assert isinstance(ld_slice, DataFrame)
+        assert isinstance(self.ld_slice, DataFrame)
         # Do we have a real square?
-        assert sqrt(ld_slice.count()) == int(sqrt(ld_slice.count()))
+        assert sqrt(self.ld_slice.count()) == int(sqrt(self.ld_slice.count()))
+
+    # def test_get_ld_variants_empty__type(
+    #     self: TestGnomADLDMatrixVariants,
+    #     ld_slice: DataFrame,
+    # ) -> None:
+    #     """Testing if the function returns the right type when the ld_slice is empty."""
+    #     ld_slice_empty = ld_slice.limit(0)
+    #     assert ld_slice_empty
 
 
 class TestGnomADLDMatrixSlice:

--- a/tests/datasource/gnomad/test_gnomad_ld.py
+++ b/tests/datasource/gnomad/test_gnomad_ld.py
@@ -91,7 +91,7 @@ class TestGnomADLDMatrixVariants:
         )
 
     @pytest.fixture(scope="class")
-    def ld_slice(self: TestGnomADLDMatrixVariants) -> DataFrame:
+    def ld_slice(self: TestGnomADLDMatrixVariants) -> DataFrame | None:
         """Generate a resolved LD slice."""
         return self.gnomad_ld_matrix.get_ld_variants(
             gnomad_ancestry="test-pop",  # observed[0],

--- a/tests/datasource/gnomad/test_gnomad_ld.py
+++ b/tests/datasource/gnomad/test_gnomad_ld.py
@@ -75,139 +75,84 @@ def test_resolve_variant_indices(
 class TestGnomADLDMatrixVariants:
     """Test the resolved LD variant sets."""
 
-    gnomad_ld_matrix: GnomADLDMatrix
-    ld_population: str = "test-pop"
-    slice_start_index: int = 1
-    slice_end_index: int = 2
+    def test_get_ld_slice_type(self: TestGnomADLDMatrixVariants) -> None:
+        """Testing if ld_slice has the right type."""
+        assert isinstance(self.ld_slice, DataFrame)
 
-    @pytest.fixture(autouse=True, scope="class")
+    def test_get_ld_empty_slice_type(self: TestGnomADLDMatrixVariants) -> None:
+        """Testing if ld_empty_slice is None."""
+        assert self.ld_empty_slice is None
+
+    def test_get_ld_variants__square(
+        self: TestGnomADLDMatrixVariants,
+    ) -> None:
+        """Testing if the function returns a square matrix."""
+        if self.ld_slice is not None:
+            assert sqrt(self.ld_slice.count()) == int(sqrt(self.ld_slice.count()))
+
+    @pytest.fixture(autouse=True)
     def _setup(self: TestGnomADLDMatrixVariants, spark: SparkSession) -> None:
-        """Initialize hail for the tests below."""
+        """Prepares fixtures for the test."""
         hl.init(sc=spark.sparkContext, log="/dev/null", idempotent=True)
-        self.gnomad_ld_matrix = GnomADLDMatrix(
+
+        ld_test_population = "test-pop"
+
+        gnomad_ld_matrix = GnomADLDMatrix(
             ld_matrix_template="tests/data_samples/example_{POP}.bm",
             ld_index_raw_template="tests/data_samples/example_{POP}.ht",
             grch37_to_grch38_chain_path="tests/data_samples/grch37_to_grch38.over.chain",
         )
-        self.ld_slice = self.gnomad_ld_matrix.get_ld_variants(
-            gnomad_ancestry="test-pop",
+        self.ld_slice = gnomad_ld_matrix.get_ld_variants(
+            gnomad_ancestry=ld_test_population,
             chromosome="1",
             start=10025,
             end=10075,
         )
-        self.ld_empty_slice = self.gnomad_ld_matrix.get_ld_variants(
-            gnomad_ancestry="test-pop",
+        self.ld_empty_slice = gnomad_ld_matrix.get_ld_variants(
+            gnomad_ancestry=ld_test_population,
             chromosome="1",
             start=0,
             end=1,
         )
 
-    # @pytest.fixture(scope="class")
-    # def ld_slice(self: TestGnomADLDMatrixVariants) -> DataFrame | None:
-    #     """Generate a resolved LD slice."""
-    #     return self.gnomad_ld_matrix.get_ld_variants(
-    #         gnomad_ancestry="test-pop",
-    #         chromosome="1",
-    #         start=10025,
-    #         end=10075,
-    #     )
-
-    # @pytest.fixture(scope="class")
-    # def ld_empty_slice(self: TestGnomADLDMatrixVariants) -> DataFrame | None:
-    #     """Generate a resolved LD slice."""
-    #     return self.gnomad_ld_matrix.get_ld_variants(
-    #         gnomad_ancestry="test-pop",
-    #         chromosome="1",
-    #         start=0,
-    #         end=1,
-    #     )
-
-    def test_get_ld_variants__type(
-        self: TestGnomADLDMatrixVariants,
-    ) -> None:
-        """Testing if the function returns the right type."""
-        # Do we have the right type?
-        assert isinstance(self.ld_slice, DataFrame)
-        # Do we have a real square?
-        assert sqrt(self.ld_slice.count()) == int(sqrt(self.ld_slice.count()))
-
-    # def test_get_ld_variants_empty__type(
-    #     self: TestGnomADLDMatrixVariants,
-    #     ld_slice: DataFrame,
-    # ) -> None:
-    #     """Testing if the function returns the right type when the ld_slice is empty."""
-    #     ld_slice_empty = ld_slice.limit(0)
-    #     assert ld_slice_empty
-
 
 class TestGnomADLDMatrixSlice:
     """Test GnomAD LD methods."""
 
-    gnomad_ld_matrix: GnomADLDMatrix
-    ld_population: str = "test-pop"
-    slice_start_index: int = 1
-    slice_end_index: int = 2
-
-    @pytest.fixture(autouse=True, scope="class")
-    def _setup(self: TestGnomADLDMatrixSlice, spark: SparkSession) -> None:
-        """Initialize hail for the tests below."""
-        hl.init(sc=spark.sparkContext, log="/dev/null", idempotent=True)
-        self.gnomad_ld_matrix = GnomADLDMatrix(
-            ld_matrix_template="tests/data_samples/example_{POP}.bm"
-        )
-
-    @pytest.fixture(scope="class")
-    def matrix_slice(self) -> DataFrame:
-        """Return a slice from the LD matrix.
-
-        Returns:
-            DataFrame: Melted LD matrix
-        """
-        return self.gnomad_ld_matrix.get_ld_matrix_slice(
-            gnomad_ancestry=self.ld_population,
-            start_index=self.slice_start_index,
-            end_index=self.slice_end_index,
-        ).persist()
-
-    def test_get_ld_matrix_slice__diagonal(
-        self: TestGnomADLDMatrixSlice, matrix_slice: DataFrame
-    ) -> None:
+    def test_get_ld_matrix_slice__diagonal(self: TestGnomADLDMatrixSlice) -> None:
         """Test LD matrix slice."""
-        # Has the returned data ones in the diagonal?
         assert (
-            matrix_slice.filter(f.col("idx_i") == f.col("idx_j"))
+            self.matrix_slice.filter(f.col("idx_i") == f.col("idx_j"))
             .select("r")
             .distinct()
             .collect()[0]["r"]
             == 1.0
-        )
+        ), "The matrix does not have ones in the diagonal."
 
-    def test_get_ld_matrix_slice__count(
-        self: TestGnomADLDMatrixSlice, matrix_slice: DataFrame
-    ) -> None:
+    def test_get_ld_matrix_slice__count(self: TestGnomADLDMatrixSlice) -> None:
         """Test LD matrix slice."""
         # As the slicing of the matrix is inclusive, the total number of rows are calculated as follows:
         included_indices = self.slice_end_index - self.slice_start_index + 1
         expected_pariwise_count = included_indices**2
 
-        # Is the returned data has the right number of rows?
-        assert matrix_slice.count() == expected_pariwise_count
+        assert (
+            self.matrix_slice.count() == expected_pariwise_count
+        ), "The matrix is not complete."
 
-    def test_get_ld_matrix_slice__type(
-        self: TestGnomADLDMatrixSlice, matrix_slice: DataFrame
-    ) -> None:
+    def test_get_ld_matrix_slice__type(self: TestGnomADLDMatrixSlice) -> None:
         """Test LD matrix slice."""
-        # Is the returned data is a dataframe?
-        assert isinstance(matrix_slice, DataFrame)
+        assert isinstance(
+            self.matrix_slice, DataFrame
+        ), "The returned data is not a dataframe."
 
     def test_get_ld_matrix_slice__symmetry(
-        self: TestGnomADLDMatrixSlice, matrix_slice: DataFrame
+        self: TestGnomADLDMatrixSlice,
     ) -> None:
         """Test LD matrix slice."""
         # Testing square matrix completeness and symmetry:
-        compared = matrix_slice.join(
+        compared = self.matrix_slice.join(
             (
-                matrix_slice.select(
+                self.matrix_slice.select(
                     f.col("idx_i").alias("idx_j"),
                     f.col("idx_j").alias("idx_i"),
                     f.col("r").alias("r_sym"),
@@ -217,8 +162,26 @@ class TestGnomADLDMatrixSlice:
             how="inner",
         )
 
-        # Is the matrix complete:
-        assert compared.count() == matrix_slice.count()
+        assert (
+            compared.count() == self.matrix_slice.count()
+        ), "The matrix is not complete."
+        assert (
+            compared.filter(f.col("r") == f.col("r_sym")).count() == compared.count()
+        ), "The matrix is not symmetric."
 
-        # Is the matrix symmetric:
-        assert compared.filter(f.col("r") == f.col("r_sym")).count() == compared.count()
+    @pytest.fixture(autouse=True)
+    def _setup(self: TestGnomADLDMatrixSlice, spark: SparkSession) -> None:
+        """Prepares fixtures for the test."""
+        hl.init(sc=spark.sparkContext, log="/dev/null", idempotent=True)
+        gnomad_ld_matrix = GnomADLDMatrix(
+            ld_matrix_template="tests/data_samples/example_{POP}.bm"
+        )
+        test_ld_population: str = "test-pop"
+        self.slice_start_index: int = 1
+        self.slice_end_index: int = 2
+
+        self.matrix_slice = gnomad_ld_matrix.get_ld_matrix_slice(
+            gnomad_ancestry=test_ld_population,
+            start_index=self.slice_start_index,
+            end_index=self.slice_end_index,
+        )


### PR DESCRIPTION
These are suggestions I had after https://github.com/opentargets/genetics_etl_python/pull/240 

This PR includes:
- Improvements in set up fixtures of the tests
- Migration of `get_value_from_row` to common spark utils module
- Refactoring of `get_value_from_row`: nones are no longer handled within the function, it simply raises an error if the input is not a row. Nones are handled outside the context of the function
- Modification of how we extract the start and end rows: by using `get_top_ranked_in_window` we make sure that the returned object is always a dataframe. Its maximum size is 1, and the minimum is 0. In this case the window is the whole dataframe.
- Modification of  `get_ld_variants`s logic not to return a spark dataframe necessarily. We make sure that start/end values are only yielded in the case where the LD table for the locus is not empty.
    - This can be easily changed once we establish how we want to use this function. It's just a matter of changing the line that return none to what we had with the empty df. 