### PR TITLE
fix: persist raw gwascat associations to return consistent results

### DIFF
--- a/src/otg/gwas_catalog.py
+++ b/src/otg/gwas_catalog.py
@@ -60,7 +60,7 @@ class GWASCatalogStep:
         )
         catalog_associations = self.session.spark.read.csv(
             self.catalog_associations_file, sep="\t", header=True
-        )
+        ).persist()
         ld_index = LDIndex.from_parquet(self.session, self.ld_index_path)
 
         # Transform


### PR DESCRIPTION
This PR surpasses the behaviour described in https://github.com/opentargets/issues/issues/3152 

I've checked various studies and they look correct. The one reported in the issue:
```python
df = session.spark.read.parquet("gs://genetics_etl_python_playground/output/python_etl/parquet/XX.XX/credible_set/catalog_curated")
df.filter(f.col("studyId") == "GCST000058").select("studyId", "variantId").show()
+----------+--------------+                                                     
|   studyId|     variantId|
+----------+--------------+
|GCST000058|6_38473194_A_G|
+----------+--------------+
```