### PR TITLE
Enable local SSDs for worker nodes

### DIFF
--- a/src/airflow/dags/common_airflow.py
+++ b/src/airflow/dags/common_airflow.py
@@ -64,7 +64,7 @@ def create_cluster(
     master_machine_type: str = "n1-highmem-8",
     worker_machine_type: str = "n1-standard-16",
     num_workers: int = 2,
-    num_local_ssds: int = 0,
+    num_local_ssds: int = 1,
 ) -> DataprocCreateClusterOperator:
     """Generate an Airflow task to create a Dataproc cluster. Common parameters are reused, and varying parameters can be specified as needed.
 
@@ -73,7 +73,7 @@ def create_cluster(
         master_machine_type (str): Machine type for the master node. Defaults to "n1-highmem-8".
         worker_machine_type (str): Machine type for the worker nodes. Defaults to "n1-standard-16".
         num_workers (int): Number of worker nodes. Defaults to 2.
-        num_local_ssds (int): How many local SSDs to attach to each worker node, both primary and secondary. Defaults to 0.
+        num_local_ssds (int): How many local SSDs to attach to each worker node, both primary and secondary. Defaults to 1.
 
     Returns:
         DataprocCreateClusterOperator: Airflow task to create a Dataproc cluster.

--- a/src/airflow/dags/common_airflow.py
+++ b/src/airflow/dags/common_airflow.py
@@ -69,9 +69,9 @@ def create_cluster(
 
     Args:
         cluster_name (str): Name of the cluster.
-        master_machine_type (str): Machine type for the master node. Defaults to "n1-standard-4".
+        master_machine_type (str): Machine type for the master node. Defaults to "n1-highmem-8".
         worker_machine_type (str): Machine type for the worker nodes. Defaults to "n1-standard-16".
-        num_workers (int): Number of worker nodes. Defaults to 0.
+        num_workers (int): Number of worker nodes. Defaults to 2.
 
     Returns:
         DataprocCreateClusterOperator: Airflow task to create a Dataproc cluster.

--- a/src/airflow/dags/common_airflow.py
+++ b/src/airflow/dags/common_airflow.py
@@ -64,6 +64,7 @@ def create_cluster(
     master_machine_type: str = "n1-highmem-8",
     worker_machine_type: str = "n1-standard-16",
     num_workers: int = 2,
+    num_local_ssds: int = 0,
 ) -> DataprocCreateClusterOperator:
     """Generate an Airflow task to create a Dataproc cluster. Common parameters are reused, and varying parameters can be specified as needed.
 
@@ -72,11 +73,13 @@ def create_cluster(
         master_machine_type (str): Machine type for the master node. Defaults to "n1-highmem-8".
         worker_machine_type (str): Machine type for the worker nodes. Defaults to "n1-standard-16".
         num_workers (int): Number of worker nodes. Defaults to 2.
+        num_local_ssds (int): How many local SSDs to attach to each worker node, both primary and secondary. Defaults to 0.
 
     Returns:
         DataprocCreateClusterOperator: Airflow task to create a Dataproc cluster.
     """
-    cluster_generator_config = ClusterGenerator(
+    # Create base cluster configuration.
+    cluster_config = ClusterGenerator(
         project_id=GCP_PROJECT,
         zone=GCP_ZONE,
         master_machine_type=master_machine_type,
@@ -94,10 +97,20 @@ def create_cluster(
         idle_delete_ttl=None,
         autoscaling_policy=f"projects/{GCP_PROJECT}/regions/{GCP_REGION}/autoscalingPolicies/{GCP_AUTOSCALING_POLICY}",
     ).make()
+
+    # If specified, amend the configuration to include local SSDs for worker nodes.
+    if num_local_ssds:
+        for worker_section in ("worker_config", "secondary_worker_config"):
+            # Create a disk config section if it does not exist.
+            cluster_config[worker_section].setdefault("disk_config", dict())
+            # Specify the number of local SSDs.
+            cluster_config[worker_section]["num_local_ssds"] = num_local_ssds
+
+    # Return the cluster creation operator.
     return DataprocCreateClusterOperator(
         task_id="create_cluster",
         project_id=GCP_PROJECT,
-        cluster_config=cluster_generator_config,
+        cluster_config=cluster_config,
         region=GCP_REGION,
         cluster_name=cluster_name,
         trigger_rule=TriggerRule.ALL_SUCCESS,

--- a/src/airflow/dags/common_airflow.py
+++ b/src/airflow/dags/common_airflow.py
@@ -84,7 +84,6 @@ def create_cluster(
         master_disk_size=500,
         worker_disk_size=500,
         num_workers=num_workers,
-        num_local_ssds=1,
         image_version=GCP_DATAPROC_IMAGE,
         enable_component_gateway=True,
         init_actions_uris=INITIALISATION_EXECUTABLE_FILE,


### PR DESCRIPTION
@d0choa @ireneisdoomed @DSuveges Please see the results of evaluating various performance approaches in https://github.com/opentargets/issues/issues/3155.

This PR implements the only tangible performance improvement that actually helps: attaching local SSDs to instances. Airflow's `ClusterGenerator` does not support this natively, and the existing `num_local_ssds=1` which is passed to it does nothing.

However, by editing the resulting config directly we can achieve this.

Closes https://github.com/opentargets/issues/issues/3155.