### PR TITLE
New clumping step

### DIFF
--- a/config/step/clump.yaml
+++ b/config/step/clump.yaml
@@ -1,0 +1,5 @@
+_target_: otg.clump.ClumpStep
+summary_stats_path: ${datasets.summary_statistics}
+study_index_path: ${datasets.study_index}
+ld_index_path: ${datasets.ld_index}
+clumped_study_locus_out: ${datasets.from_sumstats_study_locus}

--- a/docs/python_api/step/clump.md
+++ b/docs/python_api/step/clump.md
@@ -1,0 +1,4 @@
+---
+title: Clump
+---
+::: otg.clump.ClumpStep

--- a/src/otg/clump.py
+++ b/src/otg/clump.py
@@ -1,0 +1,51 @@
+"""Step to run clump summary statistics."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from omegaconf import MISSING
+
+from otg.common.session import Session
+from otg.dataset.ld_index import LDIndex
+from otg.dataset.study_index import StudyIndex
+from otg.dataset.summary_statistics import SummaryStatistics
+
+
+@dataclass
+class ClumpStep:
+    """Window-based clumping step, LD annotation and LD clumping and PICS of summary statistics.
+
+    Attributes:
+        session (Session): Session object.
+
+        summary_stats_path (str): Path to summary statistics.
+        study_index_path (str): Path to study index.
+        ld_index_path (str): Path to LD index.
+        clumped_study_locus_out (str): Output path for the clumped study locus dataset.
+    """
+
+    session: Session = MISSING
+    summary_stats_path: str = MISSING
+    study_index_path: str = MISSING
+    ld_index_path: str = MISSING
+    clumped_study_locus_out: str = MISSING
+
+    def __post_init__(self: ClumpStep) -> None:
+        """Run step."""
+        # Extract
+        summary_stats = SummaryStatistics.from_parquet(
+            self.session, self.summary_stats_path
+        )
+        ld_index = LDIndex.from_parquet(self.session, self.ld_index_path)
+        study_index = StudyIndex.from_parquet(self.session, self.study_index_path)
+
+        # Clumping
+        study_locus = (
+            summary_stats.window_based_clumping()
+            .annotate_ld(study_index=study_index, ld_index=ld_index)
+            .clump()
+        )
+        study_locus.df.write.mode(self.session.write_mode).parquet(
+            self.clumped_study_locus_out
+        )

--- a/src/otg/dataset/study_locus.py
+++ b/src/otg/dataset/study_locus.py
@@ -20,6 +20,7 @@ if TYPE_CHECKING:
     from pyspark.sql import Column, DataFrame
     from pyspark.sql.types import StructType
 
+    from otg.dataset.ld_index import LDIndex
     from otg.dataset.study_index import StudyIndex
 
 
@@ -402,6 +403,22 @@ class StudyLocus(Dataset):
             .drop("is_lead_linked")
         )
         return self
+
+    def annotate_ld(
+        self: StudyLocus, study_index: StudyIndex, ld_index: LDIndex
+    ) -> StudyLocus:
+        """Annotate LD information to study-locus.
+
+        Args:
+            study_index (StudyIndex): Study index to resolve ancestries.
+            ld_index (LDIndex): LD index to resolve LD information.
+
+        Returns:
+            StudyLocus: Study locus annotated with ld information from LD index.
+        """
+        from otg.method.ld import LDAnnotator
+
+        return LDAnnotator.ld_annotate(self, study_index, ld_index)
 
     def _qc_unresolved_ld(
         self: StudyLocus,

--- a/src/otg/dataset/summary_statistics.py
+++ b/src/otg/dataset/summary_statistics.py
@@ -68,7 +68,7 @@ class SummaryStatistics(Dataset):
             distance (int): Distance in base pairs to be used for clumping. Defaults to 500_000.
             gwas_significance (float, optional): GWAS significance threshold. Defaults to 5e-8.
             baseline_significance (float, optional): Baseline significance threshold for inclusion in the locus. Defaults to 0.05.
-            locus_collect_distance (int | None): The distance to collect locus around semi-indices. If not provided, defaults to `distance`.
+            locus_collect_distance (int | None): The distance to collect locus around semi-indices. If not provided, locus is not collected.
 
         Returns:
             StudyLocus: Clumped study-locus containing variants based on window.

--- a/src/otg/dataset/summary_statistics.py
+++ b/src/otg/dataset/summary_statistics.py
@@ -57,7 +57,7 @@ class SummaryStatistics(Dataset):
 
     def window_based_clumping(
         self: SummaryStatistics,
-        distance: int,
+        distance: int = 500_000,
         gwas_significance: float = 5e-8,
         baseline_significance: float = 0.05,
         locus_collect_distance: int | None = None,
@@ -65,7 +65,7 @@ class SummaryStatistics(Dataset):
         """Generate study-locus from summary statistics by distance based clumping + collect locus.
 
         Args:
-            distance (int): Distance in base pairs to be used for clumping.
+            distance (int): Distance in base pairs to be used for clumping. Defaults to 500_000.
             gwas_significance (float, optional): GWAS significance threshold. Defaults to 5e-8.
             baseline_significance (float, optional): Baseline significance threshold for inclusion in the locus. Defaults to 0.05.
             locus_collect_distance (int | None): The distance to collect locus around semi-indices. If not provided, defaults to `distance`.

--- a/tests/dataset/test_study_locus.py
+++ b/tests/dataset/test_study_locus.py
@@ -16,6 +16,7 @@ from pyspark.sql.types import (
     StructType,
 )
 
+from otg.dataset.ld_index import LDIndex
 from otg.dataset.study_index import StudyIndex
 from otg.dataset.study_locus import CredibleInterval, StudyLocus
 from otg.dataset.study_locus_overlap import StudyLocusOverlap
@@ -323,3 +324,12 @@ def test_annotate_credible_sets(
 def test__qc_no_population(mock_study_locus: StudyLocus) -> None:
     """Test _qc_no_population."""
     assert isinstance(mock_study_locus._qc_no_population(), StudyLocus)
+
+
+def test_ldannotate(
+    mock_study_locus: StudyLocus, mock_study_index: StudyIndex, mock_ld_index: LDIndex
+) -> None:
+    """Test ldannotate."""
+    assert isinstance(
+        mock_study_locus.annotate_ld(mock_study_index, mock_ld_index), StudyLocus
+    )


### PR DESCRIPTION
New clumping step and some accessory changes. 
- [feat: new clumping step](https://github.com/opentargets/genetics_etl_python/commit/7d94877f7e251d698ccef426ed8be970842684d0)
- [feat: annotate ld function in study locus wraps LD annotator](https://github.com/opentargets/genetics_etl_python/commit/14258d10be0f9886ee3fd619bccfa6831d323d52)
- [test: ld annotate](https://github.com/opentargets/genetics_etl_python/commit/cea5a381093505e6bf21b999306d1c49a23cc919)
- [feat: clumping distance defaults to 500_000](https://github.com/opentargets/genetics_etl_python/commit/1a190600f5760f1e3e569b014fc273cf93673b25)
- [docs: fix incorrect doc](https://github.com/opentargets/genetics_etl_python/commit/5d0cf2e527b5b7d0819a1be2b94804f08b812da5) as discussed with @DSuveges 

In the configuration, this step is configured to run on all available summary statistics. However, I have used this step only to run finngen summary statistics as part of the preprocessing by parametrising the inputs and outputs. Different from all the steps we have done so far, the intention is that this step could be reused for different inputs/outputs. 