### PR TITLE
New PICS step

### DIFF
--- a/config/datasets/gcp.yaml
+++ b/config/datasets/gcp.yaml
@@ -39,3 +39,8 @@ from_sumstats_pics: ${datasets.credible_set}/from_sumstats
 ukbiobank_study_index: ${datasets.outputs}/ukbiobank_study_index
 l2g_model: ${datasets.outputs}/l2g_model
 l2g_predictions: ${datasets.outputs}/l2g_predictions
+
+# Constants
+finngen_release_prefix: FINNGEN_R9
+finngen_sumstat_url_prefix: gs://finngen-public-data-r9/summary_stats/finngen_R9_
+finngen_sumstat_url_suffix: .gz

--- a/config/datasets/gcp.yaml
+++ b/config/datasets/gcp.yaml
@@ -25,6 +25,7 @@ gene_index: ${datasets.outputs}/gene_index
 variant_annotation: ${datasets.outputs}/variant_annotation
 variant_index: ${datasets.outputs}/variant_index
 study_locus: ${datasets.outputs}/study_locus
+credible_set: ${datasets.outputs}/credible_set
 study_locus_overlap: ${datasets.outputs}/study_locus_overlap
 colocalisation: ${datasets.outputs}/colocalisation
 v2g: ${datasets.outputs}/v2g
@@ -33,11 +34,8 @@ catalog_study_index: ${datasets.outputs}/catalog_study_index
 catalog_study_locus: ${datasets.study_locus}/catalog_study_locus
 finngen_study_index: ${datasets.outputs}/finngen_study_index
 finngen_summary_stats: ${datasets.outputs}/finngen_summary_stats
+from_sumstats_study_locus: ${datasets.study_locus}/from_sumstats
+from_sumstats_pics: ${datasets.credible_set}/from_sumstats
 ukbiobank_study_index: ${datasets.outputs}/ukbiobank_study_index
 l2g_model: ${datasets.outputs}/l2g_model
 l2g_predictions: ${datasets.outputs}/l2g_predictions
-
-# Constants
-finngen_release_prefix: FINNGEN_R9
-finngen_sumstat_url_prefix: gs://finngen-public-data-r9/summary_stats/finngen_R9_
-finngen_sumstat_url_suffix: .gz

--- a/config/datasets/gcp.yaml
+++ b/config/datasets/gcp.yaml
@@ -15,6 +15,7 @@ catalog_associations: ${datasets.inputs}/v2d/gwas_catalog_v1.0.2-associations_e1
 catalog_studies: ${datasets.inputs}/v2d/gwas-catalog-v1.0.3-studies-r2023-09-11.tsv
 catalog_ancestries: ${datasets.inputs}/v2d/gwas-catalog-v1.0.3-ancestries-r2023-09-11.tsv
 catalog_sumstats_lut: ${datasets.inputs}/v2d/harmonised_list-r2023-09-11.txt
+finngen_phenotype_table_url: https://r9.finngen.fi/api/phenos
 ukbiobank_manifest: gs://genetics-portal-input/ukb_phenotypes/neale2_saige_study_manifest.190430.tsv
 l2g_gold_standard_curation: ${datasets.inputs}/l2g/gold_standard/curation.json
 gene_interactions: ${datasets.inputs}/l2g/interaction # 23.09 data
@@ -24,12 +25,19 @@ gene_index: ${datasets.outputs}/gene_index
 variant_annotation: ${datasets.outputs}/variant_annotation
 variant_index: ${datasets.outputs}/variant_index
 study_locus: ${datasets.outputs}/study_locus
-credible_set: ${datasets.outputs}/credible_set
 study_locus_overlap: ${datasets.outputs}/study_locus_overlap
 colocalisation: ${datasets.outputs}/colocalisation
 v2g: ${datasets.outputs}/v2g
 ld_index: ${datasets.outputs}/ld_index
-from_sumstats_study_locus: ${datasets.study_locus}/from_sumstats
-from_sumstats_pics: ${datasets.credible_set}/from_sumstats
+catalog_study_index: ${datasets.outputs}/catalog_study_index
+catalog_study_locus: ${datasets.study_locus}/catalog_study_locus
+finngen_study_index: ${datasets.outputs}/finngen_study_index
+finngen_summary_stats: ${datasets.outputs}/finngen_summary_stats
+ukbiobank_study_index: ${datasets.outputs}/ukbiobank_study_index
 l2g_model: ${datasets.outputs}/l2g_model
 l2g_predictions: ${datasets.outputs}/l2g_predictions
+
+# Constants
+finngen_release_prefix: FINNGEN_R9
+finngen_sumstat_url_prefix: gs://finngen-public-data-r9/summary_stats/finngen_R9_
+finngen_sumstat_url_suffix: .gz

--- a/config/datasets/gcp.yaml
+++ b/config/datasets/gcp.yaml
@@ -15,7 +15,6 @@ catalog_associations: ${datasets.inputs}/v2d/gwas_catalog_v1.0.2-associations_e1
 catalog_studies: ${datasets.inputs}/v2d/gwas-catalog-v1.0.3-studies-r2023-09-11.tsv
 catalog_ancestries: ${datasets.inputs}/v2d/gwas-catalog-v1.0.3-ancestries-r2023-09-11.tsv
 catalog_sumstats_lut: ${datasets.inputs}/v2d/harmonised_list-r2023-09-11.txt
-finngen_phenotype_table_url: https://r9.finngen.fi/api/phenos
 ukbiobank_manifest: gs://genetics-portal-input/ukb_phenotypes/neale2_saige_study_manifest.190430.tsv
 l2g_gold_standard_curation: ${datasets.inputs}/l2g/gold_standard/curation.json
 gene_interactions: ${datasets.inputs}/l2g/interaction # 23.09 data
@@ -25,19 +24,12 @@ gene_index: ${datasets.outputs}/gene_index
 variant_annotation: ${datasets.outputs}/variant_annotation
 variant_index: ${datasets.outputs}/variant_index
 study_locus: ${datasets.outputs}/study_locus
+credible_set: ${datasets.outputs}/credible_set
 study_locus_overlap: ${datasets.outputs}/study_locus_overlap
 colocalisation: ${datasets.outputs}/colocalisation
 v2g: ${datasets.outputs}/v2g
 ld_index: ${datasets.outputs}/ld_index
-catalog_study_index: ${datasets.outputs}/catalog_study_index
-catalog_study_locus: ${datasets.study_locus}/catalog_study_locus
-finngen_study_index: ${datasets.outputs}/finngen_study_index
-finngen_summary_stats: ${datasets.outputs}/finngen_summary_stats
-ukbiobank_study_index: ${datasets.outputs}/ukbiobank_study_index
+from_sumstats_study_locus: ${datasets.study_locus}/from_sumstats
+from_sumstats_pics: ${datasets.credible_set}/from_sumstats
 l2g_model: ${datasets.outputs}/l2g_model
 l2g_predictions: ${datasets.outputs}/l2g_predictions
-
-# Constants
-finngen_release_prefix: FINNGEN_R9
-finngen_sumstat_url_prefix: gs://finngen-public-data-r9/summary_stats/finngen_R9_
-finngen_sumstat_url_suffix: .gz

--- a/config/step/pics.yaml
+++ b/config/step/pics.yaml
@@ -1,0 +1,3 @@
+_target_: otg.pics.PICSStep
+study_locus_ld_annotated_in: ${datasets.from_sumstats_study_locus}
+picsed_study_locus_out: ${datasets.from_sumstats_pics}

--- a/docs/python_api/step/pics.md
+++ b/docs/python_api/step/pics.md
@@ -1,0 +1,4 @@
+---
+title: PICS
+---
+::: otg.pics.PICSStep

--- a/src/otg/pics.py
+++ b/src/otg/pics.py
@@ -18,7 +18,7 @@ class PICSStep:
     Attributes:
         session (Session): Session object.
 
-        summary_stats_path (str): Path to summary statistics.
+        study_locus_ld_annotated_in (str): Path to Study Locus with the LD information annotated
         study_index_path (str): Path to study index.
     """
 

--- a/src/otg/pics.py
+++ b/src/otg/pics.py
@@ -1,0 +1,41 @@
+"""Step to run clump summary statistics."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from omegaconf import MISSING
+
+from otg.common.session import Session
+from otg.dataset.study_locus import StudyLocus
+from otg.method.pics import PICS
+
+
+@dataclass
+class PICSStep:
+    """PICS finemapping of LD-annotated StudyLocus.
+
+    Attributes:
+        session (Session): Session object.
+
+        summary_stats_path (str): Path to summary statistics.
+        study_index_path (str): Path to study index.
+        ld_index_path (str): Path to LD index.
+    """
+
+    session: Session = MISSING
+    study_locus_ld_annotated_in: str = MISSING
+    picsed_study_locus_out: str = MISSING
+
+    def __post_init__(self: PICSStep) -> None:
+        """Run step."""
+        # Extract
+        study_locus_ld_annotated = StudyLocus.from_parquet(
+            self.session, self.study_locus_ld_annotated_in
+        )
+        # PICS
+        picsed_sl = PICS.finemap(study_locus_ld_annotated).annotate_credible_sets()
+        # Write
+        picsed_sl.df.write.mode(self.session.write_mode).parquet(
+            self.picsed_study_locus_out
+        )

--- a/src/otg/pics.py
+++ b/src/otg/pics.py
@@ -19,7 +19,7 @@ class PICSStep:
         session (Session): Session object.
 
         study_locus_ld_annotated_in (str): Path to Study Locus with the LD information annotated
-        study_index_path (str): Path to study index.
+        picsed_study_locus_out (str): Path to Study Locus after running PICS
     """
 
     session: Session = MISSING

--- a/src/otg/pics.py
+++ b/src/otg/pics.py
@@ -1,4 +1,4 @@
-"""Step to run clump summary statistics."""
+"""Step to apply PICS finemapping."""
 
 from __future__ import annotations
 

--- a/src/otg/pics.py
+++ b/src/otg/pics.py
@@ -20,7 +20,6 @@ class PICSStep:
 
         summary_stats_path (str): Path to summary statistics.
         study_index_path (str): Path to study index.
-        ld_index_path (str): Path to LD index.
     """
 
     session: Session = MISSING


### PR DESCRIPTION
New step to run PICS on study locus with annotated LD:

- [feat: new PICS step](https://github.com/opentargets/genetics_etl_python/commit/c9d8dd9d1dfc5e987080d8fecc43cbc8abda4a7a)
- [feat: configuration for PICS step](https://github.com/opentargets/genetics_etl_python/commit/0c5878c0546814d02ac076ea15031e3af3b7ff72)
- [docs: pics step](https://github.com/opentargets/genetics_etl_python/commit/e73732e322583253d36e5a97c01f6ffccb8e1fd6)

Similar to #258, this step is configured to run on all available study locus with annotated LD. However, I have used this step only to run finngen study locus as part of the preprocessing by parametrising the inputs and outputs. Different from all the steps we have done so far, clumping and pics could be reused for different inputs/outputs.

A successful run of this step is available here (running after clumping): https://console.cloud.google.com/dataproc/jobs/5b921713-7e47-4202-8381-1210ff1d317b/monitoring?region=europe-west1&project=open-targets-genetics-dev

The resulting dataset is in: `gs://genetics_etl_python_playground/output/python_etl/parquet/XX.XX/credible_set/from_sumstats_study_locus/finngen`