### PR TITLE
feat: raise error in `from_parquet` when df is empty

### DIFF
--- a/src/otg/dataset/dataset.py
+++ b/src/otg/dataset/dataset.py
@@ -84,9 +84,14 @@ class Dataset(ABC):
 
         Returns:
             Self: Dataset with the parquet file contents
+
+        Raises:
+            ValueError: Parquet file is empty
         """
         schema = cls.get_schema()
         df = session.read_parquet(path=path, schema=schema, **kwargs)
+        if df.isEmpty():
+            raise ValueError(f"Parquet file is empty: {path}")
         return cls(_df=df, _schema=schema)
 
     def validate_schema(self: Dataset) -> None:


### PR DESCRIPTION
This PR raises an error in `Dataset.from_parquet` if the file is found to be empty, preventing silent failures in data pipelines.

`isEmpty()` works by invoking `limit(1).count()`, which means that forces the evaluation of this operation in the Spark plan. I don't think this will have a major impact in the performance, and reading operations are done very early in the pipeline. And, if anything, the step will fail faster.

I've come across this bug a few times, most recently when accessing the credible set folder for L2G. I think that due to incompatible schemas from various sources, querying this folder returned an empty dataframe.
