### PR TITLE
feat: split gwascatalog step into process steps

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -57,7 +57,7 @@ repos:
         stages: [commit-msg]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: "v1.7.0"
+    rev: "v1.7.1"
     hooks:
       - id: mypy
         args: [

--- a/config/step/gwas_catalog_ingestion.yaml
+++ b/config/step/gwas_catalog_ingestion.yaml
@@ -1,4 +1,4 @@
-_target_: otg.gwas_catalog.GWASCatalogStep
+_target_: otg.gwas_catalog_ingestion.GWASCatalogStep
 catalog_studies_file: ${datasets.catalog_studies}
 catalog_ancestry_file: ${datasets.catalog_ancestries}
 catalog_associations_file: ${datasets.catalog_associations}

--- a/config/step/gwas_catalog_ingestion.yaml
+++ b/config/step/gwas_catalog_ingestion.yaml
@@ -4,6 +4,5 @@ catalog_ancestry_file: ${datasets.catalog_ancestries}
 catalog_associations_file: ${datasets.catalog_associations}
 catalog_sumstats_lut: ${datasets.catalog_sumstats_lut}
 variant_annotation_path: ${datasets.variant_annotation}
-ld_index_path: ${datasets.ld_index}
 catalog_studies_out: ${datasets.catalog_study_index}
 catalog_associations_out: ${datasets.catalog_study_locus}

--- a/docs/python_api/step/clump.md
+++ b/docs/python_api/step/clump.md
@@ -1,0 +1,4 @@
+---
+title: Clump
+---
+::: otg.clump.ClumpStep

--- a/docs/python_api/step/gwas_catalog.md
+++ b/docs/python_api/step/gwas_catalog.md
@@ -1,4 +1,0 @@
----
-title: GWAS Catalog
----
-::: otg.gwas_catalog.GWASCatalogStep

--- a/docs/python_api/step/gwas_catalog_ingestion.md
+++ b/docs/python_api/step/gwas_catalog_ingestion.md
@@ -1,0 +1,4 @@
+---
+title: GWAS Catalog
+---
+::: otg.gwas_catalog_ingestion.GWASCatalogStep

--- a/src/airflow/dags/common_airflow.py
+++ b/src/airflow/dags/common_airflow.py
@@ -289,24 +289,6 @@ def read_yaml_config(config_path: Path) -> Any:
         return yaml.safe_load(config_file)
 
 
-# def generate_dag(cluster_name: str, tasks: list[DataprocSubmitJobOperator]) -> Any:
-#     """For a list of tasks, generate a complete DAG.
-
-#     Args:
-#         cluster_name (str): Name of the cluster.
-#         tasks (list[DataprocSubmitJobOperator]): List of tasks to execute.
-
-#     Returns:
-#         Any: Airflow DAG.
-#     """
-#     return (
-#         create_cluster(cluster_name)
-#         >> install_dependencies(cluster_name)
-#         >> tasks
-#         >> delete_cluster(cluster_name)
-#     )
-
-
 def generate_dag(
     cluster_name: str, tasks: list[Union[BaseOperator, TaskGroup]]
 ) -> None:

--- a/src/airflow/dags/configs/dag.yaml
+++ b/src/airflow/dags/configs/dag.yaml
@@ -1,4 +1,4 @@
-# - id: "gene_index"
+- id: "gene_index"
 - id: "gwas_catalog"
   tasks:
     - id: "gwas_catalog_ingestion"
@@ -11,22 +11,22 @@
       args:
         study_locus_ld_annotated_in: study_locus/catalog_study_locus
         picsed_study_locus_out: credible_set/catalog_curated
-# - id: "variant_index"
-#   prerequisites:
-#     - "gwas_catalog"
-# - id: "v2g"
-#   prerequisites:
-#     - "variant_index"
-#     - "gene_index"
-# - id: "ukbiobank"
-# - id: "study_locus_overlap"
-#   prerequisites:
-#     - "gwas_catalog"
-#     - "ukbiobank"
-# - id: "locus_to_gene"
-#   prerequisites:
-#     - "gwas_catalog"
-#     - "ukbiobank"
-#     - "variant_index"
-#     - "v2g"
-#     - "study_locus_overlap"
+- id: "variant_index"
+  prerequisites:
+    - "gwas_catalog"
+- id: "v2g"
+  prerequisites:
+    - "variant_index"
+    - "gene_index"
+- id: "ukbiobank"
+- id: "study_locus_overlap"
+  prerequisites:
+    - "gwas_catalog"
+    - "ukbiobank"
+- id: "locus_to_gene"
+  prerequisites:
+    - "gwas_catalog"
+    - "ukbiobank"
+    - "variant_index"
+    - "v2g"
+    - "study_locus_overlap"

--- a/src/airflow/dags/configs/dag.yaml
+++ b/src/airflow/dags/configs/dag.yaml
@@ -1,21 +1,32 @@
-- id: "gene_index"
+# - id: "gene_index"
 - id: "gwas_catalog"
-- id: "variant_index"
-  prerequisites:
-    - "gwas_catalog"
-- id: "v2g"
-  prerequisites:
-    - "variant_index"
-    - "gene_index"
-- id: "ukbiobank"
-- id: "study_locus_overlap"
-  prerequisites:
-    - "gwas_catalog"
-    - "ukbiobank"
-- id: "locus_to_gene"
-  prerequisites:
-    - "gwas_catalog"
-    - "ukbiobank"
-    - "variant_index"
-    - "v2g"
-    - "study_locus_overlap"
+  tasks:
+    - id: "gwas_catalog_ingestion"
+    - id: "clump"
+      args:
+        input_path: study_locus/catalog_study_locus
+        study_index_path: catalog_study_index
+        clumped_study_locus_path: study_locus/catalog_study_locus
+    - id: "pics"
+      args:
+        study_locus_ld_annotated_in: study_locus/catalog_study_locus
+        picsed_study_locus_out: credible_set/catalog_curated
+# - id: "variant_index"
+#   prerequisites:
+#     - "gwas_catalog"
+# - id: "v2g"
+#   prerequisites:
+#     - "variant_index"
+#     - "gene_index"
+# - id: "ukbiobank"
+# - id: "study_locus_overlap"
+#   prerequisites:
+#     - "gwas_catalog"
+#     - "ukbiobank"
+# - id: "locus_to_gene"
+#   prerequisites:
+#     - "gwas_catalog"
+#     - "ukbiobank"
+#     - "variant_index"
+#     - "v2g"
+#     - "study_locus_overlap"

--- a/src/airflow/dags/dag_genetics_etl.py
+++ b/src/airflow/dags/dag_genetics_etl.py
@@ -1,14 +1,18 @@
 """Airflow DAG for the ETL part of the pipeline."""
+
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Dict, Union
 
 import common_airflow as common
+from airflow.models import BaseOperator
 from airflow.models.dag import DAG
+from airflow.utils.task_group import TaskGroup
 
-CLUSTER_NAME = "otg-etl"
+CLUSTER_NAME = "otg-etl-il"
 SOURCE_CONFIG_FILE_PATH = Path(__file__).parent / "configs" / "dag.yaml"
-
+RELEASEBUCKET = "gs://genetics_etl_python_playground/output/python_etl/parquet/XX.XX"
 
 with DAG(
     dag_id=Path(__file__).stem,
@@ -17,18 +21,42 @@ with DAG(
     **common.shared_dag_kwargs,
 ):
     # Parse and define all steps and their prerequisites.
-    tasks = {}
-    steps = common.read_yaml_config(SOURCE_CONFIG_FILE_PATH)
-    for step in steps:
-        # Define task for the current step.
-        step_id = step["id"]
-        this_task = common.submit_step(
-            cluster_name=CLUSTER_NAME,
-            step_id=step_id,
-        )
-        # Chain prerequisites.
-        tasks[step_id] = this_task
-        for prerequisite in step.get("prerequisites", []):
-            this_task.set_upstream(tasks[prerequisite])
+    tasks: Dict[str, Union[BaseOperator, TaskGroup]] = {}
+    nodes = common.read_yaml_config(SOURCE_CONFIG_FILE_PATH)
+
+    for node in nodes:
+        node_id = node["id"]
+        if "tasks" in node:
+            # Group of tasks for nodes with multiple tasks
+            with TaskGroup(node_id) as tgroup:
+                prev_task = None
+                for task in node["tasks"]:
+                    parsed_args = [
+                        f"step.{key}={value}"
+                        for key, value in task.get("args", {}).items()
+                    ]
+                    current_task = common.submit_step(
+                        cluster_name=CLUSTER_NAME,
+                        step_id=task["id"],
+                        other_args=parsed_args,
+                    )
+                    if prev_task:
+                        prev_task >> current_task
+                    prev_task = current_task
+
+            tasks[node_id] = tgroup
+        else:
+            # Single task step
+            tasks[node_id] = common.submit_step(
+                cluster_name=CLUSTER_NAME,
+                step_id=node_id,
+            )
+
+    # Chain prerequisites.
+    for prerequisite in node.get("prerequisites", []):
+        if prerequisite in tasks:
+            # Set upstream for both TaskGroup and BaseOperator
+            tasks[node_id].set_upstream(tasks[prerequisite])
+
     # Construct the DAG with all tasks.
-    dag = common.generate_dag(cluster_name=CLUSTER_NAME, tasks=list(tasks.values()))
+    common.generate_dag(cluster_name=CLUSTER_NAME, tasks=list(tasks.values()))

--- a/src/airflow/dags/dag_genetics_etl.py
+++ b/src/airflow/dags/dag_genetics_etl.py
@@ -12,7 +12,7 @@ from airflow.utils.task_group import TaskGroup
 
 CLUSTER_NAME = "otg-etl-il"
 SOURCE_CONFIG_FILE_PATH = Path(__file__).parent / "configs" / "dag.yaml"
-RELEASEBUCKET = "gs://genetics_etl_python_playground/output/python_etl/parquet/XX.XX"
+RELEASEBUCKET = "gs://genetics_etl_python_playground/output/python_etl/parquet/XX.XX/"
 
 with DAG(
     dag_id=Path(__file__).stem,
@@ -32,7 +32,7 @@ with DAG(
                 prev_task = None
                 for task in node["tasks"]:
                     parsed_args = [
-                        f"step.{key}={value}"
+                        f"step.{key}={RELEASEBUCKET}{value}"
                         for key, value in task.get("args", {}).items()
                     ]
                     current_task = common.submit_step(

--- a/src/otg/clump.py
+++ b/src/otg/clump.py
@@ -1,0 +1,81 @@
+"""Step to run clump associations from summary statistics or study locus."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+
+from omegaconf import MISSING
+
+from otg.common.session import Session
+from otg.dataset.ld_index import LDIndex
+from otg.dataset.study_index import StudyIndex
+from otg.dataset.study_locus import StudyLocus
+from otg.dataset.summary_statistics import SummaryStatistics
+
+
+class ClumpMethod(Enum):
+    """Method of clumping to use."""
+
+    LD_BASED = "ld_based"
+    WINDOW_BASED = "window_based"
+
+
+@dataclass
+class ClumpStep:
+    """Clumping step with customizable method.
+
+    Attributes:
+        session (Session): Session object.
+        clump_method (ClumpMethod): Method of clumping to use.
+        study_index_path (str): Path to study index.
+        ld_index_path (str): Path to LD index.
+        clumped_study_locus_path (str): Output path for the clumped study locus dataset.
+    """
+
+    session: Session = MISSING
+    clump_method: ClumpMethod = MISSING
+    input_path: str = MISSING
+    study_index_path: str = MISSING
+    ld_index_path: str = MISSING
+    clumped_study_locus_path: str = MISSING
+    data: StudyLocus | SummaryStatistics = field(init=False)
+
+    def __post_init__(self: ClumpStep) -> None:
+        """Run the clumping step.
+
+        Raises:
+            ValueError: If clump method is not supported.
+        """
+        # Extract data by defining data type
+        input_cols = self.session.spark.read.parquet(self.input_path).columns
+        if "studyLocusId" in input_cols:
+            self.data = StudyLocus.from_parquet(self.session, self.input_path)
+        else:
+            self.data = SummaryStatistics.from_parquet(self.session, self.input_path)
+
+        # Transform
+        if self.clump_method.value not in [
+            ClumpMethod.LD_BASED.value,
+            ClumpMethod.WINDOW_BASED.value,
+        ]:
+            raise ValueError(f"Clump method {self.clump_method} not supported.")
+
+        elif self.clump_method == ClumpMethod.WINDOW_BASED and isinstance(
+            self.data, SummaryStatistics
+        ):
+            clumped_study_locus = self.data.window_based_clumping()
+
+        elif self.clump_method == ClumpMethod.LD_BASED and isinstance(
+            self.data, StudyLocus
+        ):
+            ld_index = LDIndex.from_parquet(self.session, self.ld_index_path)
+            study_index = StudyIndex.from_parquet(self.session, self.study_index_path)
+
+            clumped_study_locus = self.data.annotate_ld(
+                study_index=study_index, ld_index=ld_index
+            ).clump()
+
+        # Load
+        clumped_study_locus.df.write.mode(self.session.write_mode).parquet(
+            self.clumped_study_locus_path
+        )

--- a/src/otg/clump.py
+++ b/src/otg/clump.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from enum import Enum
 
 from omegaconf import MISSING
 
@@ -13,69 +12,41 @@ from otg.dataset.study_locus import StudyLocus
 from otg.dataset.summary_statistics import SummaryStatistics
 
 
-class ClumpMethod(Enum):
-    """Method of clumping to use."""
-
-    LD_BASED = "ld_based"
-    WINDOW_BASED = "window_based"
-
-
 @dataclass
 class ClumpStep:
     """Clumping step with customizable method.
 
     Attributes:
         session (Session): Session object.
-        clump_method (ClumpMethod): Method of clumping to use.
+        input_path (str): Input path for the study locus or summary statistics files.
         study_index_path (str): Path to study index.
         ld_index_path (str): Path to LD index.
         clumped_study_locus_path (str): Output path for the clumped study locus dataset.
     """
 
     session: Session = MISSING
-    clump_method: ClumpMethod = MISSING
     input_path: str = MISSING
     study_index_path: str = MISSING
     ld_index_path: str = MISSING
     clumped_study_locus_path: str = MISSING
+
     data: StudyLocus | SummaryStatistics = field(init=False)
 
     def __post_init__(self: ClumpStep) -> None:
-        """Run the clumping step.
-
-        Raises:
-            ValueError: If clump method is not supported.
-        """
-        # Extract data by defining data type
+        """Run the clumping step."""
         input_cols = self.session.spark.read.parquet(self.input_path).columns
         if "studyLocusId" in input_cols:
             self.data = StudyLocus.from_parquet(self.session, self.input_path)
-        else:
-            self.data = SummaryStatistics.from_parquet(self.session, self.input_path)
-
-        # Transform
-        if self.clump_method.value not in [
-            ClumpMethod.LD_BASED.value,
-            ClumpMethod.WINDOW_BASED.value,
-        ]:
-            raise ValueError(f"Clump method {self.clump_method} not supported.")
-
-        elif self.clump_method == ClumpMethod.WINDOW_BASED and isinstance(
-            self.data, SummaryStatistics
-        ):
-            clumped_study_locus = self.data.window_based_clumping()
-
-        elif self.clump_method == ClumpMethod.LD_BASED and isinstance(
-            self.data, StudyLocus
-        ):
             ld_index = LDIndex.from_parquet(self.session, self.ld_index_path)
             study_index = StudyIndex.from_parquet(self.session, self.study_index_path)
 
             clumped_study_locus = self.data.annotate_ld(
                 study_index=study_index, ld_index=ld_index
             ).clump()
+        else:
+            self.data = SummaryStatistics.from_parquet(self.session, self.input_path)
+            clumped_study_locus = self.data.window_based_clumping()
 
-        # Load
         clumped_study_locus.df.write.mode(self.session.write_mode).parquet(
             self.clumped_study_locus_path
         )

--- a/src/otg/clump.py
+++ b/src/otg/clump.py
@@ -14,7 +14,13 @@ from otg.dataset.summary_statistics import SummaryStatistics
 
 @dataclass
 class ClumpStep:
-    """Clumping step with customizable method.
+    """Perform clumping of an association dataset to identify independent signals.
+
+    Two types of clumping are supported and are applied based on the input dataset:
+    - Clumping of summary statistics based on a window-based approach.
+    - Clumping of study locus based on LD.
+
+    Both approaches yield a StudyLocus dataset.
 
     Attributes:
         session (Session): Session object.

--- a/src/otg/dataset/study_locus.py
+++ b/src/otg/dataset/study_locus.py
@@ -13,6 +13,7 @@ from otg.common.spark_helpers import (
     order_array_of_structs_by_field,
 )
 from otg.dataset.dataset import Dataset
+from otg.dataset.ld_index import LDIndex
 from otg.dataset.study_locus_overlap import StudyLocusOverlap
 from otg.method.clump import LDclumping
 
@@ -367,6 +368,22 @@ class StudyLocus(Dataset):
             ),
         )
         return self
+
+    def annotate_ld(
+        self: StudyLocus, study_index: StudyIndex, ld_index: LDIndex
+    ) -> StudyLocus:
+        """Annotate LD information to study-locus.
+
+        Args:
+            study_index (StudyIndex): Study index to resolve ancestries.
+            ld_index (LDIndex): LD index to resolve LD information.
+
+        Returns:
+            StudyLocus: Study locus annotated with ld information from LD index.
+        """
+        from otg.method.ld import LDAnnotator
+
+        return LDAnnotator.ld_annotate(self, study_index, ld_index)
 
     def clump(self: StudyLocus) -> StudyLocus:
         """Perform LD clumping of the studyLocus.

--- a/src/otg/dataset/summary_statistics.py
+++ b/src/otg/dataset/summary_statistics.py
@@ -57,7 +57,7 @@ class SummaryStatistics(Dataset):
 
     def window_based_clumping(
         self: SummaryStatistics,
-        distance: int,
+        distance: int = 500_000,
         gwas_significance: float = 5e-8,
         baseline_significance: float = 0.05,
         locus_collect_distance: int | None = None,

--- a/tests/dataset/test_study_locus.py
+++ b/tests/dataset/test_study_locus.py
@@ -16,6 +16,7 @@ from pyspark.sql.types import (
     StructType,
 )
 
+from otg.dataset.ld_index import LDIndex
 from otg.dataset.study_index import StudyIndex
 from otg.dataset.study_locus import CredibleInterval, StudyLocus
 from otg.dataset.study_locus_overlap import StudyLocusOverlap
@@ -323,3 +324,12 @@ def test_annotate_credible_sets(
 def test__qc_no_population(mock_study_locus: StudyLocus) -> None:
     """Test _qc_no_population."""
     assert isinstance(mock_study_locus._qc_no_population(), StudyLocus)
+
+
+def test_ldannotate(
+    mock_study_locus: StudyLocus, mock_study_index: StudyIndex, mock_ld_index: LDIndex
+) -> None:
+    """Test ldannotate."""
+    assert isinstance(
+        mock_study_locus.annotate_ld(mock_study_index, mock_ld_index), StudyLocus
+    )


### PR DESCRIPTION
This branch is the application of the concept scoped in `il-clump-step`.

Instead of having a recipe (step) per dataset that processes all the inputs from start to finish, we define a number of common recipes that we want to apply on the data. In my opinion, the modularisation removes duplication of code and adds flexibility.

Thinking about the GWAS Catalog curation ingestion, instead of having a `gwas_catalog` step with the full journey, we now have groups of tasks:
<img width="700" alt="image" src="https://github.com/opentargets/genetics_etl_python/assets/45119610/5b115cc8-363f-4eb7-9b1b-02e69dd50c9e">

- gwas_catalog_ingestion stops at the ingestion of the curated associations and the study table
- clump, to perform LD clumping
- pics, to perform fine mapping

Tasks are defined in `dag.yaml` as we used to do, only that the parsing to generate the DAG has more logic.
To me, the main caveat for this approach as of today is the fact that we have to provide the inputs/outputs at the DAG level.
