### PR TITLE
Il fix studies split

### DIFF
--- a/src/otg/datasource/gwas_catalog/study_splitter.py
+++ b/src/otg/datasource/gwas_catalog/study_splitter.py
@@ -74,7 +74,7 @@ class GWASCatalogStudySplitter:
         """
         split_w = Window.partitionBy(study_id).orderBy(sub_study_description)
         row_number = f.dense_rank().over(split_w)
-        substudy_count = f.count(row_number).over(split_w)
+        substudy_count = f.approx_count_distinct(row_number).over(split_w)
         return f.when(substudy_count == 1, study_id).otherwise(
             f.concat_ws("_", study_id, row_number)
         )

--- a/tests/datasource/gwas_catalog/test_gwas_catalog_study_splitter.py
+++ b/tests/datasource/gwas_catalog/test_gwas_catalog_study_splitter.py
@@ -1,9 +1,17 @@
 """Tests GWAS Catalog study splitter."""
 from __future__ import annotations
 
+from typing import TYPE_CHECKING, Any
+
+import pyspark.sql.functions as f
+import pytest
+
 from otg.datasource.gwas_catalog.associations import GWASCatalogAssociations
 from otg.datasource.gwas_catalog.study_index import GWASCatalogStudyIndex
 from otg.datasource.gwas_catalog.study_splitter import GWASCatalogStudySplitter
+
+if TYPE_CHECKING:
+    from pyspark.sql import SparkSession
 
 
 def test_gwas_catalog_splitter_split(
@@ -17,3 +25,65 @@ def test_gwas_catalog_splitter_split(
 
     assert isinstance(d1, GWASCatalogStudyIndex)
     assert isinstance(d2, GWASCatalogAssociations)
+
+
+@pytest.mark.parametrize(
+    "observed, expected",
+    [
+        # Test 1 - it shouldn't split
+        (
+            # observed - 2 associations with the same subStudy annotation
+            [
+                (
+                    "varA",
+                    "GCST003436",
+                    "Endometrial cancer|no_pvalue_text|EFO_1001512",
+                ),
+                (
+                    "varB",
+                    "GCST003436",
+                    "Endometrial cancer|no_pvalue_text|EFO_1001512",
+                ),
+            ],
+            # expected - 2 associations with the same unsplit updatedStudyId
+            [
+                ("GCST003436",),
+                ("GCST003436",),
+            ],
+        ),
+        # Test 2 - it should split
+        (
+            # observed - 2 associations with the different   subStudy annotation
+            [
+                (
+                    "varA",
+                    "GCST003436",
+                    "Endometrial cancer|no_pvalue_text|EFO_1001512",
+                ),
+                (
+                    "varB",
+                    "GCST003436",
+                    "Uterine carcinoma|no_pvalue_text|EFO_0002919",
+                ),
+            ],
+            # expected - 2 associations with the same unsplit updatedStudyId
+            [
+                ("GCST003436",),
+                ("GCST003436_2",),
+            ],
+        ),
+    ],
+)
+def test__resolve_study_id(
+    spark: SparkSession, observed: list[Any], expected: list[Any]
+) -> None:
+    """Test _resolve_study_id."""
+    observed_df = spark.createDataFrame(
+        observed, schema=["variantId", "studyId", "subStudyDescription"]
+    ).select(
+        GWASCatalogStudySplitter._resolve_study_id(
+            f.col("studyId"), f.col("subStudyDescription").alias("updatedStudyId")
+        )
+    )
+    expected_df = spark.createDataFrame(expected, schema=["updatedStudyId"])
+    assert observed_df.collect() == expected_df.collect()


### PR DESCRIPTION
## Problem
The source of the error where studies were split even though the metadata was the same resided in the `_resolve_study_id` logic.

This function windows over each study and sorts by "subStudyDescription", which is the column that contains the metadata for splitting. You can see the problem very clearly here:
```
+----------+---------------------------------------------+-------------+---------+--------------+
|studyId   |subStudyDescription                          |subStudyCount|rowNumber|updatedStudyId|
+----------+---------------------------------------------+-------------+---------+--------------+
|GCST003436|Endometrial cancer|no_pvalue_text|EFO_1001512|4            |1        |GCST003436_1  |
|GCST003436|Endometrial cancer|no_pvalue_text|EFO_1001512|4            |1        |GCST003436_1  |
|GCST003436|Endometrial cancer|no_pvalue_text|EFO_1001512|4            |1        |GCST003436_1  |
|GCST003436|Endometrial cancer|no_pvalue_text|EFO_1001512|4            |1        |GCST003436_1  |
+----------+---------------------------------------------+-------------+---------+--------------+
```
We have **4 associations** with the same studyId/subStudyCount. subStudyCount counts the number of `rowNumber`, not the number of unique `rowNumber`. Therefore in the logic, this studyId had to be split.

## Fix
The fix makes that we count the number of distinct rowNumber. I had to use `approx_count_distinct`, because `count_distinct` cannot be used on a window. I think that calculating an approximation is fine, there is a very limited number of metadata around a single study.

## Testing
I've added two tests to see the behaviour with and without splitting. We now don't have any study with a `_1` suffix.