### PR TITLE
test: try to fix Codecov configuration

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -35,7 +35,6 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.xml
           fail_ci_if_error: true
           verbose: true


### PR DESCRIPTION
There was this dependabot PR which I confirmed was working and merged: https://github.com/opentargets/genetics_etl_python/pull/301

The tests were passing in the PR, but after merging they failed in the main branch with the following error message:

`[2023-12-04T20:52:25.943Z] ['error'] There was an error running the uploader: Error uploading to https://codecov.io: Error: There was an error fetching the storage URL during POST: 404 - {'detail': ErrorDetail(string='Could not find a repository associated with upload token ***', code='not_found')}`

Our project indeed has a `CODECOV_TOKEN` secret, which is picked up by the workflow. It was updated 15 hours ago, and it looks like the tests have started failing since then.

Codecov documentation [mentions](https://docs.codecov.com/docs/frequently-asked-questions) (first question, last paragraph) that this token is not required for public repositories, so my idea is that by removing this entirely we might resolve the problem.