### PR TITLE
perf: improve join between gold standards and overlaps

### DIFF
--- a/src/otg/dataset/study_locus_overlap.py
+++ b/src/otg/dataset/study_locus_overlap.py
@@ -55,12 +55,14 @@ class StudyLocusOverlap(Dataset):
             StudyLocusOverlap: Square matrix of the dataset
         """
         return StudyLocusOverlap(
-            _df=self.df.unionByName(
+            _df=self.df.select("leftStudyLocusId", "rightStudyLocusId", "tagVariantId")
+            .unionByName(
                 self.df.selectExpr(
                     "leftStudyLocusId as rightStudyLocusId",
                     "rightStudyLocusId as leftStudyLocusId",
                     "tagVariantId",
                 )
-            ).distinct(),
+            )
+            .distinct(),
             _schema=self.get_schema(),
         )


### PR DESCRIPTION
Overlaps is used to build the gold standard in the step where redundant associations are removed. With the current approach, the size of the overlaps dataset represents a bottleneck in the L2G pipeline.
This PR contains:
1. Joining operation is now split into two steps. This only impacts performance, business logic should remain the same:
- Filtering overlaps to include only associations present in the gold standard. Overlaps are on the left side of the join, and gold standard is broadcasted.
- Joining of the overlapping associations onto the gold standards. Gold standards are on the left side of the join, overlapping associations is broadcasted.
2. `_convert_to_square_matrix` only returns relevant columns, this is to minimise data that needs to be shuffled

I've run this solution and I don't see the problem anymore.
