### PR TITLE
feat: new changelog and release notes templates 

### DIFF
--- a/templates/.release_notes.md.j2
+++ b/templates/.release_notes.md.j2
@@ -1,0 +1,7 @@
+## What's Changed
+{% for type_, commits in release["elements"] | dictsort %}
+### {{ type_ | capitalize }}
+{%- if type_ != "unknown" %}
+{% for commit in commits %}
+* {{ commit.descriptions[0] }} by {{commit.commit.author.name}} in [`{{ commit.short_hash }}`]({{ commit.hexsha | commit_hash_url }})
+{%- endfor %}{% endif %}{% endfor %}

--- a/templates/.release_notes.md.j2
+++ b/templates/.release_notes.md.j2
@@ -7,5 +7,5 @@
 ### {{ add_emoji(type_) }} {{ type_ | capitalize }}
 {%- if type_ != "unknown" %}
 {% for commit in commits %}
-- {{ commit_content(commit.commit.summary) }} {{ commit.commit.summary }} - [`{{ commit.commit.hexsha[:7] }}`]({{ commit.commit.hexsha | commit_hash_url }}) ([{{ commit.commit.author.name }}](mailto:{{commit.commit.author.email}}))
+- {{ commit_content(commit.commit.summary) }} - [`{{ commit.commit.hexsha[:7] }}`]({{ commit.commit.hexsha | commit_hash_url }}) ([{{ commit.commit.author.name }}](mailto:{{commit.commit.author.email}}))
 {%- endfor %}{% endif %}{% endfor %}

--- a/templates/.release_notes.md.j2
+++ b/templates/.release_notes.md.j2
@@ -1,7 +1,11 @@
+{% macro add_emoji(commit_type) %}{% if commit_type == "feature" %}✨{% elif commit_type == "fix" %}🐛{% elif commit_type == "documentation" %}📖{% elif commit_type == "style" %}🎨{% elif commit_type == "refactor" %}♻️{% elif commit_type == "test" %}✅{% elif commit_type == "chore" %}🚀{% elif commit_type == "performance" %}⚡️{% elif commit_type == "ci" %}👷‍♂️{% elif commit_type == "build" %}🏗{% elif commit_type == "breaking" %}💥{% elif commit_type == "unknown" %}🤷‍♂️{% elif commit_type == "revert" %}⏪{% else %}🤷‍♂️{% endif %}{% endmacro %}
+
+{% macro commit_scope(commit_summary) %}{{ commit_summary.split(":")[0] }}{% endmacro %}
+{% macro commit_content(commit_summary) %}{{ commit_summary.split(":")[1] }}{% endmacro %}
 ## What's Changed
 {% for type_, commits in release["elements"] | dictsort %}
-### {{ type_ | capitalize }}
+### {{ add_emoji(type_) }} {{ type_ | capitalize }}
 {%- if type_ != "unknown" %}
 {% for commit in commits %}
-* {{ commit.descriptions[0] }} by {{commit.commit.author.name}} in [`{{ commit.short_hash }}`]({{ commit.hexsha | commit_hash_url }})
+- {{ commit_content(commit.commit.summary) }} {{ commit.commit.summary }} - [`{{ commit.commit.hexsha[:7] }}`]({{ commit.commit.hexsha | commit_hash_url }}) ([{{ commit.commit.author.name }}](mailto:{{commit.commit.author.email}}))
 {%- endfor %}{% endif %}{% endfor %}

--- a/templates/CHANGELOG.md.j2
+++ b/templates/CHANGELOG.md.j2
@@ -1,0 +1,25 @@
+# CHANGELOG
+{% if context.history.unreleased | length > 0 %}
+
+{# UNRELEASED #}
+## Unreleased
+{% for type_, commits in context.history.unreleased | dictsort %}
+### {{ type_ | capitalize }}
+{% for commit in commits %}{% if type_ != "unknown" %}
+* {{ commit.commit.message.rstrip() }} ([`{{ commit.commit.hexsha[:7] }}`]({{ commit.commit.hexsha | commit_hash_url }}))
+{% else %}
+* {{ commit.commit.message.rstrip() }} ([`{{ commit.commit.hexsha[:7] }}`]({{ commit.commit.hexsha | commit_hash_url }}))
+{% endif %}{% endfor %}{% endfor %}
+
+{% endif %}
+
+{# RELEASED #}
+{% for version, release in context.history.released.items() %}
+## {{ version.as_tag() }} ({{ release.tagged_date.strftime("%Y-%m-%d") }})
+{% for type_, commits in release["elements"] | dictsort %}
+### {{ type_ | capitalize }}
+{% for commit in commits %}{% if type_ != "unknown" %}
+* {{ commit.commit.message.rstrip() }} ([`{{ commit.commit.hexsha[:7] }}`]({{ commit.commit.hexsha | commit_hash_url }}))
+{% else %}
+* {{ commit.commit.message.rstrip() }} ([`{{ commit.commit.hexsha[:7] }}`]({{ commit.commit.hexsha | commit_hash_url }}))
+{% endif %}{% endfor %}{% endfor %}{% endfor %}

--- a/templates/CHANGELOG.md.j2
+++ b/templates/CHANGELOG.md.j2
@@ -10,9 +10,9 @@
 {% for type_, commits in context.history.unreleased | dictsort %}
 ### add_emoji({{type_}}) {{ type_ | capitalize }}
 {% for commit in commits %}{% if type_ != "unknown" %}
-- {{ commit_content(commit.commit.summary) }} {{ commit.commit.summary }} - [`{{ commit.commit.hexsha[:7] }}`]({{ commit.commit.hexsha | commit_hash_url }}) ([{{ commit.commit.author.name }}](mailto:{{commit.commit.author.email}}))
+- {{ commit_content(commit.commit.summary) }} - [`{{ commit.commit.hexsha[:7] }}`]({{ commit.commit.hexsha | commit_hash_url }}) ([{{ commit.commit.author.name }}](mailto:{{commit.commit.author.email}}))
 {% else %}
-- {{ commit_content(commit.commit.summary) }} {{ commit.commit.summary }} - [`{{ commit.commit.hexsha[:7] }}`]({{ commit.commit.hexsha | commit_hash_url }}) ([{{ commit.commit.author.name }}](mailto:{{commit.commit.author.email}}))
+- {{ commit_content(commit.commit.summary) }} - [`{{ commit.commit.hexsha[:7] }}`]({{ commit.commit.hexsha | commit_hash_url }}) ([{{ commit.commit.author.name }}](mailto:{{commit.commit.author.email}}))
 {% endif %}{% endfor %}{% endfor %}{% endif %}
 
 {# RELEASED #}
@@ -21,7 +21,7 @@
 {% for type_, commits in release["elements"] | dictsort %}
 ### {{ add_emoji(type_) }} {{ type_ | capitalize }}
 {% for commit in commits %}{% if type_ != "unknown" %}
-- {{ commit_content(commit.commit.summary) }} {{ commit.commit.summary }} - [`{{ commit.commit.hexsha[:7] }}`]({{ commit.commit.hexsha | commit_hash_url }}) ([{{ commit.commit.author.name }}](mailto:{{commit.commit.author.email}}))
+- {{ commit_content(commit.commit.summary) }} - [`{{ commit.commit.hexsha[:7] }}`]({{ commit.commit.hexsha | commit_hash_url }}) ([{{ commit.commit.author.name }}](mailto:{{commit.commit.author.email}}))
 {% else %}
-- {{ commit_content(commit.commit.summary) }} {{ commit.commit.summary }} - [`{{ commit.commit.hexsha[:7] }}`]({{ commit.commit.hexsha | commit_hash_url }}) ([{{ commit.commit.author.name }}](mailto:{{commit.commit.author.email}}))
+- {{ commit_content(commit.commit.summary) }} - [`{{ commit.commit.hexsha[:7] }}`]({{ commit.commit.hexsha | commit_hash_url }}) ([{{ commit.commit.author.name }}](mailto:{{commit.commit.author.email}}))
 {% endif %}{% endfor %}{% endfor %}{% endfor %}

--- a/templates/CHANGELOG.md.j2
+++ b/templates/CHANGELOG.md.j2
@@ -1,25 +1,27 @@
+{% macro add_emoji(commit_type) %}{% if commit_type == "feature" %}✨{% elif commit_type == "fix" %}🐛{% elif commit_type == "documentation" %}📖{% elif commit_type == "style" %}🎨{% elif commit_type == "refactor" %}♻️{% elif commit_type == "test" %}✅{% elif commit_type == "chore" %}🚀{% elif commit_type == "performance" %}⚡️{% elif commit_type == "ci" %}👷‍♂️{% elif commit_type == "build" %}🏗{% elif commit_type == "breaking" %}💥{% elif commit_type == "unknown" %}🤷‍♂️{% elif commit_type == "revert" %}⏪{% else %}🤷‍♂️{% endif %}{% endmacro %}
+
+{% macro commit_scope(commit_summary) %}{{ commit_summary.split(":")[0] }}{% endmacro %}
+{% macro commit_content(commit_summary) %}{{ commit_summary.split(":")[1] }}{% endmacro %}
 # CHANGELOG
 {% if context.history.unreleased | length > 0 %}
 
 {# UNRELEASED #}
 ## Unreleased
 {% for type_, commits in context.history.unreleased | dictsort %}
-### {{ type_ | capitalize }}
+### add_emoji({{type_}}) {{ type_ | capitalize }}
 {% for commit in commits %}{% if type_ != "unknown" %}
-* {{ commit.commit.message.rstrip() }} ([`{{ commit.commit.hexsha[:7] }}`]({{ commit.commit.hexsha | commit_hash_url }}))
+- {{ commit_content(commit.commit.summary) }} {{ commit.commit.summary }} - [`{{ commit.commit.hexsha[:7] }}`]({{ commit.commit.hexsha | commit_hash_url }}) ([{{ commit.commit.author.name }}](mailto:{{commit.commit.author.email}}))
 {% else %}
-* {{ commit.commit.message.rstrip() }} ([`{{ commit.commit.hexsha[:7] }}`]({{ commit.commit.hexsha | commit_hash_url }}))
-{% endif %}{% endfor %}{% endfor %}
-
-{% endif %}
+- {{ commit_content(commit.commit.summary) }} {{ commit.commit.summary }} - [`{{ commit.commit.hexsha[:7] }}`]({{ commit.commit.hexsha | commit_hash_url }}) ([{{ commit.commit.author.name }}](mailto:{{commit.commit.author.email}}))
+{% endif %}{% endfor %}{% endfor %}{% endif %}
 
 {# RELEASED #}
 {% for version, release in context.history.released.items() %}
 ## {{ version.as_tag() }} ({{ release.tagged_date.strftime("%Y-%m-%d") }})
 {% for type_, commits in release["elements"] | dictsort %}
-### {{ type_ | capitalize }}
+### {{ add_emoji(type_) }} {{ type_ | capitalize }}
 {% for commit in commits %}{% if type_ != "unknown" %}
-* {{ commit.commit.message.rstrip() }} ([`{{ commit.commit.hexsha[:7] }}`]({{ commit.commit.hexsha | commit_hash_url }}))
+- {{ commit_content(commit.commit.summary) }} {{ commit.commit.summary }} - [`{{ commit.commit.hexsha[:7] }}`]({{ commit.commit.hexsha | commit_hash_url }}) ([{{ commit.commit.author.name }}](mailto:{{commit.commit.author.email}}))
 {% else %}
-* {{ commit.commit.message.rstrip() }} ([`{{ commit.commit.hexsha[:7] }}`]({{ commit.commit.hexsha | commit_hash_url }}))
+- {{ commit_content(commit.commit.summary) }} {{ commit.commit.summary }} - [`{{ commit.commit.hexsha[:7] }}`]({{ commit.commit.hexsha | commit_hash_url }}) ([{{ commit.commit.author.name }}](mailto:{{commit.commit.author.email}}))
 {% endif %}{% endfor %}{% endfor %}{% endfor %}


### PR DESCRIPTION
Proposed changes modify the changelog from the current one...

<img width="538" alt="Screenshot 2023-12-17 at 22 10 12" src="https://github.com/opentargets/genetics_etl_python/assets/5097586/35452549-77d3-4710-9463-27d35b1742e4">

to the new one...

<img width="639" alt="Screenshot 2023-12-17 at 22 21 58" src="https://github.com/opentargets/genetics_etl_python/assets/5097586/07d03fd8-be3b-4755-9eba-2dbbc409eebe">


(I'm not the most skilled jinja 🥷 programmer)