### PR TITLE
fix(l2g): `calculate_feature_missingness_rate` counts features annotated with 0 as incomplete

### DIFF
--- a/src/otg/dataset/l2g_feature_matrix.py
+++ b/src/otg/dataset/l2g_feature_matrix.py
@@ -109,7 +109,12 @@ class L2GFeatureMatrix(Dataset):
             raise ValueError("No features found")
 
         return {
-            feature: (self._df.filter(self._df[feature].isNull()).count() / total_count)
+            feature: (
+                self._df.filter(
+                    (self._df[feature].isNull()) | (self._df[feature] == 0)
+                ).count()
+                / total_count
+            )
             for feature in self.features_list
         }
 

--- a/src/otg/method/l2g/evaluator.py
+++ b/src/otg/method/l2g/evaluator.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 import itertools
 from typing import TYPE_CHECKING, Any, Dict
 
-import wandb
 from pyspark import keyword_only
 from pyspark.ml.evaluation import (
     BinaryClassificationEvaluator,
@@ -13,9 +12,10 @@ from pyspark.ml.evaluation import (
 )
 from pyspark.ml.param import Param, Params, TypeConverters
 
+from wandb.sdk.wandb_run import Run
+
 if TYPE_CHECKING:
     from pyspark.sql import DataFrame
-    from wandb.wandb_run import Run
 
 
 class WandbEvaluator(Evaluator):
@@ -124,11 +124,11 @@ class WandbEvaluator(Evaluator):
         """
         return self.getOrDefault(self.spark_ml_evaluator)
 
-    def getwandb_run(self: WandbEvaluator) -> wandb.sdk.wandb_run.Run:
+    def getwandb_run(self: WandbEvaluator) -> Run:
         """Get the wandb_run parameter.
 
         Returns:
-            wandb.sdk.wandb_run.Run: Wandb run object.
+            Run: Wandb run object.
         """
         return self.getOrDefault(self.wandb_run)
 

--- a/src/otg/method/l2g/evaluator.py
+++ b/src/otg/method/l2g/evaluator.py
@@ -11,7 +11,6 @@ from pyspark.ml.evaluation import (
     MulticlassClassificationEvaluator,
 )
 from pyspark.ml.param import Param, Params, TypeConverters
-
 from wandb.sdk.wandb_run import Run
 
 if TYPE_CHECKING:

--- a/src/otg/method/l2g/model.py
+++ b/src/otg/method/l2g/model.py
@@ -12,13 +12,13 @@ from pyspark.ml.evaluation import (
 )
 from pyspark.ml.feature import StringIndexer, VectorAssembler
 from pyspark.ml.tuning import ParamGridBuilder
+from wandb.data_types import Table
+from wandb.sdk import init as wandb_init
+from wandb.wandb_run import Run
 from xgboost.spark.core import SparkXGBClassifierModel
 
 from otg.dataset.l2g_feature_matrix import L2GFeatureMatrix
 from otg.method.l2g.evaluator import WandbEvaluator
-from wandb.data_types import Table
-from wandb.sdk import init as wandb_init
-from wandb.wandb_run import Run
 
 if TYPE_CHECKING:
     from pyspark.ml import Transformer

--- a/src/otg/method/l2g/model.py
+++ b/src/otg/method/l2g/model.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Type
 
-import wandb
 from pyspark.ml import Pipeline, PipelineModel
 from pyspark.ml.evaluation import (
     BinaryClassificationEvaluator,
@@ -13,11 +12,13 @@ from pyspark.ml.evaluation import (
 )
 from pyspark.ml.feature import StringIndexer, VectorAssembler
 from pyspark.ml.tuning import ParamGridBuilder
-from wandb.wandb_run import Run
 from xgboost.spark.core import SparkXGBClassifierModel
 
 from otg.dataset.l2g_feature_matrix import L2GFeatureMatrix
 from otg.method.l2g.evaluator import WandbEvaluator
+from wandb.data_types import Table
+from wandb.sdk import init as wandb_init
+from wandb.wandb_run import Run
 
 if TYPE_CHECKING:
     from pyspark.ml import Transformer
@@ -126,7 +127,7 @@ class LocusToGeneModel:
         ## Track feature importance
         wandb_run.log({"importances": self.get_feature_importance()})
         ## Track training set
-        training_table = wandb.Table(dataframe=training_data.df.toPandas())
+        training_table = Table(dataframe=training_data.df.toPandas())
         wandb_run.log({"trainingSet": training_table})
         # Count number of positive and negative labels
         gs_counts_dict = {
@@ -224,7 +225,7 @@ class LocusToGeneModel:
         )
 
         if wandb_run_name and training_data:
-            run = wandb.init(
+            run = wandb_init(
                 project=self.wandb_l2g_project_name,
                 config=hyperparameters,
                 name=wandb_run_name,


### PR DESCRIPTION
This PR includes:
- change to `calculate_feature_missingness_rate` to count as incomplete studyLoci where the extracted feature has a value of 0.0
- `calculate_feature_missingness_rate` test
- minor typing improvements related to wandb

In the latest run with the newer VEP features, missingness for all available features was 0. This is incorrect, there is a preliminary step in the L2G's matrix where I fill all nulls with 0s. So only taking nulls into consideration is not valid.
<img width="1037" alt="image" src="https://github.com/opentargets/genetics_etl_python/assets/45119610/de887461-8532-4e19-b02b-0afcb0f14242">