### PR TITLE
chore: set cluster delete TTL

### DIFF
--- a/src/airflow/dags/common_airflow.py
+++ b/src/airflow/dags/common_airflow.py
@@ -102,7 +102,7 @@ def create_cluster(
             "CONFIGTAR": CONFIG_TAG,
             "PACKAGE": PACKAGE_WHEEL,
         },
-        idle_delete_ttl=None,
+        idle_delete_ttl=30 * 60,  # In seconds.
         autoscaling_policy=f"projects/{GCP_PROJECT}/regions/{GCP_REGION}/autoscalingPolicies/{autoscaling_policy}",
     ).make()
 


### PR DESCRIPTION
Closes https://github.com/opentargets/issues/issues/3184.

We decided that half an hour is a sensible amount of time to allow the cluster to be idle: in a debugging mode, it allows the developer to fix the issue and restart without recreating the cluster; while in a failsafe mode, it will stop the cluster after running idle for any meaningful amount of time.