### PR TITLE
feat(study_locus): remove statistics after conditioning from schema

### DIFF
--- a/src/otg/assets/schemas/study_locus.json
+++ b/src/otg/assets/schemas/study_locus.json
@@ -166,18 +166,6 @@
             },
             {
               "metadata": {},
-              "name": "pValueMantissaConditioned",
-              "nullable": true,
-              "type": "float"
-            },
-            {
-              "metadata": {},
-              "name": "pValueExponentConditioned",
-              "nullable": true,
-              "type": "integer"
-            },
-            {
-              "metadata": {},
               "name": "beta",
               "nullable": true,
               "type": "double"
@@ -185,18 +173,6 @@
             {
               "metadata": {},
               "name": "standardError",
-              "nullable": true,
-              "type": "double"
-            },
-            {
-              "metadata": {},
-              "name": "betaConditioned",
-              "nullable": true,
-              "type": "double"
-            },
-            {
-              "metadata": {},
-              "name": "standardErrorConditioned",
               "nullable": true,
               "type": "double"
             },

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -192,7 +192,7 @@ def mock_study_locus_data(spark: SparkSession) -> DataFrame:
         .withColumnSpec("finemappingMethod", percentNulls=0.1)
         .withColumnSpec(
             "locus",
-            expr='array(named_struct("is95CredibleSet", cast(rand() > 0.5 as boolean), "is99CredibleSet", cast(rand() > 0.5 as boolean), "logABF", rand(), "posteriorProbability", rand(), "variantId", cast(rand() as string), "beta", rand(), "standardError", rand(), "betaConditioned", rand(), "standardErrorConditioned", rand(), "r2Overall", rand(), "pValueMantissaConditioned", rand(), "pValueExponentConditioned", rand(), "pValueMantissa", rand(), "pValueExponent", rand()))',
+            expr='array(named_struct("is95CredibleSet", cast(rand() > 0.5 as boolean), "is99CredibleSet", cast(rand() > 0.5 as boolean), "logABF", rand(), "posteriorProbability", rand(), "variantId", cast(rand() as string), "beta", rand(), "standardError", rand(), "r2Overall", rand(), "pValueMantissa", rand(), "pValueExponent", rand()))',
             percentNulls=0.1,
         )
     )


### PR DESCRIPTION
This PR includes:
- deletion of the variant statistics after conditioning from the StudyLocus schema

## Context
Inside a `locus`, we have a couple of statistics that describe the association between a variant and the trait after doing conditional analysis.
COJO does conditioning, and that is why we were maintaining these fields. However our current implementation does not include adjusting the p values based on other signals in the locus.

Given the current size of our locus object, I think we're better off without these null fields polluting the codebase.