### PR TITLE
chore: change picsed finngen outputh path

### DIFF
--- a/src/airflow/dags/finngen_preprocess.py
+++ b/src/airflow/dags/finngen_preprocess.py
@@ -16,7 +16,7 @@ WINDOWBASED_CLUMPED = (
     f"{RELEASEBUCKET}/study_locus/from_sumstats_study_locus_window_clumped/finngen"
 )
 LD_CLUMPED = f"{RELEASEBUCKET}/study_locus/from_sumstats_study_locus_ld_clumped/finngen"
-PICSED = f"{RELEASEBUCKET}/credible_set/from_sumstats_study_locus/finngen"
+PICSED = f"{RELEASEBUCKET}/credible_set/from_sumstats/finngen"
 
 with DAG(
     dag_id=Path(__file__).stem,


### PR DESCRIPTION
to align it with `gwas_catalog_preprocess.py`