### PR TITLE
fix: some GWAS Catalog study curation logic fix - column names

### DIFF
--- a/src/airflow/dags/gwas_catalog_preprocess.py
+++ b/src/airflow/dags/gwas_catalog_preprocess.py
@@ -190,4 +190,5 @@ with DAG(
         >> upload_task
         >> curation_processing
         >> summary_satistics_processing
+        >> common.delete_cluster(CLUSTER_NAME)
     )


### PR DESCRIPTION
This PR is quite trivial: some of the column names were not matching in study curation logic.