### PR TITLE
fix: deprecate __version__ in __init__.py

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,8 +90,8 @@ match = "(main|master)"
 prerelease = false
 
 [tool.semantic_release.branches."release"]
-match = "il-reorder-release-template"
-prerelease = false
+match = "release/*"
+prerelease = true
 prerelease_token = "rc"
 
 [tool.semantic_release.publish]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,7 +81,6 @@ yamllint = "^1.33.0"
 logging_use_named_masks = true
 build_command = "pip install poetry && poetry build"
 assets = []
-version_variable = ["src/otg/__init__.py:__version__"]
 version_toml = ["pyproject.toml:tool.poetry.version"]
 upload_to_pypi = false
 upload_to_release = true
@@ -91,8 +90,8 @@ match = "(main|master)"
 prerelease = false
 
 [tool.semantic_release.branches."release"]
-match = "release/*"
-prerelease = true
+match = "il-reorder-release-template"
+prerelease = false
 prerelease_token = "rc"
 
 [tool.semantic_release.publish]

--- a/src/otg/__init__.py
+++ b/src/otg/__init__.py
@@ -1,5 +1,3 @@
 """Modules supporting Genetics Portal analysis."""
 
 from __future__ import annotations
-
-__version__ = "0.0.0"


### PR DESCRIPTION
This is falling out of fashion when using modern build systems (e.g. poetry). More info here:
https://stackoverflow.com/questions/72167802/adding-version-attribute-to-python-module