### PR TITLE
refactor: rename genetics_etl_python to gentropy

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          repository: opentargets/genetics_etl_python
+          repository: opentargets/gentropy
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Python Semantic Release

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 [![status: experimental](https://github.com/GIScience/badges/raw/master/status/experimental.svg)](https://github.com/GIScience/badges#experimental)
-[![docs](https://github.com/opentargets/genetics_etl_python/actions/workflows/docs.yaml/badge.svg)](https://opentargets.github.io/genetics_etl_python/)
-[![codecov](https://codecov.io/gh/opentargets/genetics_etl_python/branch/main/graph/badge.svg?token=5ixzgu8KFP)](https://codecov.io/gh/opentargets/genetics_etl_python)
+[![docs](https://github.com/opentargets/gentropy/actions/workflows/docs.yaml/badge.svg)](https://opentargets.github.io/gentropy/)
+[![codecov](https://codecov.io/gh/opentargets/gentropy/branch/main/graph/badge.svg?token=5ixzgu8KFP)](https://codecov.io/gh/opentargets/gentropy)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
-[![pre-commit.ci status](https://results.pre-commit.ci/badge/github/opentargets/genetics_etl_python/main.svg)](https://results.pre-commit.ci/badge/github/opentargets/genetics_etl_python)
+[![pre-commit.ci status](https://results.pre-commit.ci/badge/github/opentargets/gentropy/main.svg)](https://results.pre-commit.ci/badge/github/opentargets/gentropy)
 
 # Genetics Portal Data Pipeline (experimental)
 
-- [Documentation](https://opentargets.github.io/genetics_etl_python/)
+- [Documentation](https://opentargets.github.io/gentropy/)

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,10 +18,10 @@ hide:
 ---
 
 [![status: experimental](https://github.com/GIScience/badges/raw/master/status/experimental.svg)](https://github.com/GIScience/badges#experimental)
-![docs](https://github.com/opentargets/genetics_etl_python/actions/workflows/docs.yaml/badge.svg)
-[![codecov](https://codecov.io/gh/opentargets/genetics_etl_python/branch/main/graph/badge.svg?token=5ixzgu8KFP)](https://codecov.io/gh/opentargets/genetics_etl_python)
+![docs](https://github.com/opentargets/gentropy/actions/workflows/docs.yaml/badge.svg)
+[![codecov](https://codecov.io/gh/opentargets/gentropy/branch/main/graph/badge.svg?token=5ixzgu8KFP)](https://codecov.io/gh/opentargets/gentropy)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
-[![pre-commit.ci status](https://results.pre-commit.ci/badge/github/opentargets/genetics_etl_python/main.svg)](https://results.pre-commit.ci/badge/github/opentargets/genetics_etl_python)
+[![pre-commit.ci status](https://results.pre-commit.ci/badge/github/opentargets/gentropy/main.svg)](https://results.pre-commit.ci/badge/github/opentargets/gentropy)
 
 ---
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -31,7 +31,7 @@ plugins:
         - assets/schemas/*
   # Show git commiters in the footer
   - git-committers:
-      repository: opentargets/genetics_etl_python
+      repository: opentargets/gentropy
       branch: main
 
 markdown_extensions:
@@ -51,8 +51,8 @@ markdown_extensions:
 hooks:
   - src/utils/schemadocs.py
 
-repo_name: opentargets/genetics_etl_python
-repo_url: https://github.com/opentargets/genetics_etl_python
+repo_name: opentargets/gentropy
+repo_url: https://github.com/opentargets/gentropy
 
 theme:
   name: "material"
@@ -90,7 +90,7 @@ theme:
 extra:
   social:
     - icon: fontawesome/brands/github
-      link: https://github.com/genetics_etl_python
+      link: https://github.com/gentropy
 
 extra_css:
   - assets/stylesheets/extra.css

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,8 +6,8 @@ description = "Open targets Genetics Portal Python ETL"
 authors = ["Open Targets core team"]
 license = "Apache-2.0"
 readme = "README.md"
-documentation = "https://opentargets.github.io/genetics_etl_python/"
-repository = "https://github.com/opentargets/genetics_etl_python"
+documentation = "https://opentargets.github.io/gentropy/"
+repository = "https://github.com/opentargets/gentropy"
 packages = [{ include = "gentropy", from = "src" }]
 
 [tool.poetry.urls]


### PR DESCRIPTION
These changes are necessary for renaming the GitHub repo from `genetics_etl_python` to `gentropy`